### PR TITLE
Click and drag outside modal closes the modal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,12 @@
 # TODO
 
-- [ ] Add geolocation to every comment.
+## features
+
+- [x] Add geolocation to every comment.
 - [ ] Create method on Comment schema for editing comments; should trigger geolocate.
-- [ ] Auth modal closes when click and drag out of modal.
 - [ ] Look into nginx module for resizing images; nginx http filter module.
 
-# Bugs
+## bugs
 
 - [ ] Comment then reply to comment, if delete parent get error:
 ```
@@ -19,4 +20,5 @@ dispatchEvent
 performConcurrentWorkOnRoot
 [native code]
 ```
-- [ ] Cannot right click or cmd + click to open post cards in new tab.
+- [x] Cannot right click or cmd + click to open post cards in new tab.
+- [x] Auth modal closes when click and drag out of modal.

--- a/client/src/components/modals/auth/Auth.tsx
+++ b/client/src/components/modals/auth/Auth.tsx
@@ -17,8 +17,19 @@ interface AuthProps {
 
 const Auth: React.FC<AuthProps> = ({ onClose }) => {
     const { isAuthenticated } = useSelector((state: RootState) => state.user);
-
     const [modalContent, setModalContent] = useState<'LOGIN' | 'USER_DETAILS' | 'REGISTER' | 'FORGOT_PASSWORD'>(isAuthenticated ? 'USER_DETAILS' : 'LOGIN');
+
+    const [isMouseDownInside, setIsMouseDownInside] = useState(false);
+
+    const handleMouseDown = (e: React.MouseEvent) => {
+        setIsMouseDownInside(e.currentTarget === e.target);
+    }
+
+    const handleMouseUp = (e: React.MouseEvent) => {
+        if (isMouseDownInside && e.currentTarget === e.target) {
+            onClose();
+        }
+    }
 
     const renderView = (view: string): JSX.Element => {
         switch (view) {
@@ -36,7 +47,7 @@ const Auth: React.FC<AuthProps> = ({ onClose }) => {
                 );
             case 'REGISTER':
                 return (
-                    <Register 
+                    <Register
                         onSwitchToLogin={() => setModalContent('LOGIN')}
                         onClose={onClose}
                     />
@@ -53,7 +64,7 @@ const Auth: React.FC<AuthProps> = ({ onClose }) => {
     }
 
     return (
-        <ModalOverlay onClick={onClose}>
+        <ModalOverlay onMouseDown={handleMouseDown} onMouseUp={handleMouseUp}>
             <ModalContainer onClick={(e) => e.stopPropagation()}>
                 {renderView(modalContent)}
             </ModalContainer>


### PR DESCRIPTION
Brought to my attention by @guy-bartkus. Clicking and dragging outside of the modal window closes the window.