### PR TITLE
`MetaTags` for enriched social sharing

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-DEV_MODE=true
+NEXT_PUBLIC_DEV_MODE=true
 MONGO_URI=mongodb://127.0.0.1:27017/
 REDUX_LOGGER=false

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -28,7 +28,7 @@ const nextConfig = {
     reactStrictMode: false,
 }
 
-if (!process.env.DEV_MODE) {
+if (process.env.DEV_MODE === 'true') {
     nextConfig.rewrites = rewrite;
 } else {
     nextConfig.output = "export";

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -28,7 +28,7 @@ const nextConfig = {
     reactStrictMode: false,
 }
 
-if (process.env.DEV_MODE === 'true') {
+if (process.env.NEXT_PUBLIC_DEV_MODE === 'true') {
     nextConfig.rewrites = rewrite;
 } else {
     nextConfig.output = "export";

--- a/client/public/site-images/512-logo.png
+++ b/client/public/site-images/512-logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf0370abf4ff5d029c6390af3a5d314533de5b845ba3ebfe243ca1a18848eb80
+size 10918

--- a/client/src/components/atomic/MetaTags.tsx
+++ b/client/src/components/atomic/MetaTags.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Head from 'next/head';
+
+interface Props {
+    title: string;
+    description: string;
+    image: string;
+    url: string;
+}
+
+const MetaTags: React.FC<Props> = ({ title, description, image, url }) => {
+    return (
+        <Head>
+            <title>{title}</title>
+            <meta name="description" content={description} />
+            <link rel="canonical" href={url} />
+            <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+
+            <meta property="og:title" content={title} />
+            <meta property="og:description" content={description} />
+            <meta property="og:image" content={image} />
+            <meta property="og:url" content={url} />
+
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:title" content={title} />
+            <meta name="twitter:description" content={description} />
+            <meta name="twitter:image" content={image} />
+        </Head>
+    );
+};
+
+export default MetaTags;

--- a/client/src/components/pages/index-page/IndexPage.tsx
+++ b/client/src/components/pages/index-page/IndexPage.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@store/store';
 import CardPreview from '@components/pages/index-page/CardPreview';
 import TagFilter from '@components/ui/TagFilter';
+import MetaTags from '@components/atomic/MetaTags';
 
 import { theme } from '@styles/theme';
 
@@ -25,7 +26,17 @@ const Grid = styled.div`
     grid-gap: 20px;
 `;
 
-const IndexPage = ({ posts }: { posts: PostMetadata[] }) => {
+interface IndexPageProps {
+    posts: PostMetadata[];
+    meta: {
+        title: string;
+        description: string;
+        image: string;
+        url: string;
+    }
+}
+
+const IndexPage = ({ posts, meta }: IndexPageProps) => {
     const allTags = Array.from(new Set(posts.flatMap(post => post.tags))).sort();
     const [selectedTags, setSelectedTags] = useState<string[]>([]);
     const filteredPosts = selectedTags.length > 0 ? posts.filter(
@@ -43,20 +54,23 @@ const IndexPage = ({ posts }: { posts: PostMetadata[] }) => {
     const tagsFilterVisible = useSelector((state: RootState) => state.visibility.tagsFilterVisible);
 
     return (
-        <Container>
-            <TagFilter
-                tags={allTags}
-                selectedTags={selectedTags}
-                onTagSelect={handleTagSelect}
-                onTagDeselect={handleTagDeselect}
-                visible={tagsFilterVisible}
-            />
-            <Grid>
-                {filteredPosts.map(post => (
-                    <CardPreview key={post.slug} {...post} />
-                ))}
-            </Grid>
-        </Container>
+        <>
+            <MetaTags {...meta} />
+            <Container>
+                <TagFilter
+                    tags={allTags}
+                    selectedTags={selectedTags}
+                    onTagSelect={handleTagSelect}
+                    onTagDeselect={handleTagDeselect}
+                    visible={tagsFilterVisible}
+                />
+                <Grid>
+                    {filteredPosts.map(post => (
+                        <CardPreview key={post.slug} {...post} />
+                    ))}
+                </Grid>
+            </Container>
+        </>
     );
 };
 

--- a/client/src/components/pages/post-page/PostPage.tsx
+++ b/client/src/components/pages/post-page/PostPage.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { MDXRemote } from 'next-mdx-remote';
 
@@ -5,6 +6,7 @@ import { MDXRemote } from 'next-mdx-remote';
 import { useSelector } from 'react-redux';
 import { RootState } from '@store/store';
 
+import { APPLICATION_METADATA, APPLICATION_URL } from '@constants/config';
 import TagFilter from '@components/ui/TagFilter';
 import { PostContainer, Article, PostContentWrapper } from '@components/pages/post';
 import SideBar from '@components/pages/post-page/SideBar';
@@ -13,6 +15,8 @@ import CommentSection from '@components/comments-section/CommentSection';
 // ------------------------------------
 // component imports to be used in MDX
 import { mdxComponents } from '@components/pages/post-page/mdxComponents';
+import MetaTags from '@components/atomic/MetaTags';
+
 
 interface FrontMatter {
     slug?: string;
@@ -29,11 +33,19 @@ interface FrontMatter {
 interface PostPageProps {
     section: string;
     frontmatter: FrontMatter;
+    summary: string;
     source: any;
     side_bar_data: FrontMatter[];
 }
 
-const PostPage: React.FC<PostPageProps> = ({ section, frontmatter, source, side_bar_data }) => {
+const PostPage: React.FC<PostPageProps> = ({ section, frontmatter, summary, source, side_bar_data }) => {
+    const router = useRouter();
+
+    APPLICATION_METADATA.title = `DN | ${frontmatter.title}`;
+    APPLICATION_METADATA.description = summary;
+    APPLICATION_METADATA.image = APPLICATION_URL + '/site-images/card-covers/' + frontmatter.coverImage + '.png';
+    APPLICATION_METADATA.url = APPLICATION_URL + router.asPath;
+
     // https://nextjs.org/docs/messages/react-hydration-error
     // Solution 1: Using useEffect to run on the client only; used to fix mathjax not rendering
     const [isClient, setIsClient] = useState(false)
@@ -67,6 +79,7 @@ const PostPage: React.FC<PostPageProps> = ({ section, frontmatter, source, side_
 
     return (
         <>
+            <MetaTags {...APPLICATION_METADATA} />
             <TagFilter
                 tags={all_tags}
                 selectedTags={selectedTags}

--- a/client/src/constants/config.ts
+++ b/client/src/constants/config.ts
@@ -1,16 +1,26 @@
 import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '../../../.env' });
 
 // root starts at client/src
-export const ROOT = path.join(process.cwd(), 'src');
+export const ROOT: string = path.join(process.cwd(), 'src');
 export const ROOT_PUBLIC: string = path.join(process.cwd());
-export const APPLICATION_TITLE = 'derecksnotes.com';
+
+// app domain
+export const APPLICATION_DOMAIN: string = 'derecksnotes.com';
+export const APPLICATION_URL: string = (process.env.DEV_MODE === 'true' ? 'next.' : '') + APPLICATION_DOMAIN;
+
+// author info
 export const APPLICATION_AUTHOR: { first_name: string, last_name: string } = { first_name: 'Dereck', last_name: 'Mezquita' };
 
+// time and date
 // 1 days, 24 hours, 60 minutes, 60 seconds, 1000 milliseconds
-export const REFRESH_STORE_DATA_INTERVAL = 1 * 2 * 60 * 60 * 1000;
+export const REFRESH_STORE_DATA_INTERVAL: number = 1 * 2 * 60 * 60 * 1000;
 
+// defaults for users
 export const DEFAULT_PROFILE_IMAGE: string = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><rect width='100' height='100' fill='%23ccc' /><text x='50%' y='50%' font-size='40' text-anchor='middle' dy='.3em' fill='%23777'>?</text></svg>";
 
+// api
 export const API_PREFIX: string = '/api/v3';
-
 export const MAX_COMMENT_DEPTH: number = 5;

--- a/client/src/constants/config.ts
+++ b/client/src/constants/config.ts
@@ -9,10 +9,24 @@ export const ROOT_PUBLIC: string = path.join(process.cwd());
 
 // app domain
 export const APPLICATION_DOMAIN: string = 'derecksnotes.com';
-export const APPLICATION_URL: string = (process.env.DEV_MODE === 'true' ? 'next.' : '') + APPLICATION_DOMAIN;
+export const APPLICATION_SUBDOMAIN: string = process.env.NEXT_PUBLIC_DEV_MODE === 'true' ? 'next.' : '';
+export const APPLICATION_URL: string = APPLICATION_SUBDOMAIN + APPLICATION_DOMAIN;
 
-// author info
+// social images
+export const APPLICATION_LOGO: string = APPLICATION_URL + '/site-images/512-logo.png';
+
+// site info
+export const APPLICATION_DESCRIPTION: string = "Making sciencing easier.";
 export const APPLICATION_AUTHOR: { first_name: string, last_name: string } = { first_name: 'Dereck', last_name: 'Mezquita' };
+
+export const APPLICATION_METADATA: {
+    title: string, description: string, image: string, url: string
+} = {
+    title: 'Dereck\'s Notes',
+    description: APPLICATION_DESCRIPTION,
+    image: APPLICATION_LOGO,
+    url: APPLICATION_URL
+};
 
 // time and date
 // 1 days, 24 hours, 60 minutes, 60 seconds, 1000 milliseconds

--- a/client/src/pages/blog/[slug].tsx
+++ b/client/src/pages/blog/[slug].tsx
@@ -12,10 +12,15 @@ const Post = (props: any) => {
 
 // ----------------------------------------
 import { getMDXSource, getSidebarData } from '@components/pages/post-page/postHelpers';
+import { get_single_post_metadata } from '@utils/markdown/get_post_metadata';
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
     const side_bar_data = getSidebarData(section);
     const mdxSource = await getMDXSource(section, params!.slug as string);
+    let summary: string = get_single_post_metadata(section, params!.slug as string + '.mdx').summary || '';
+
+    // only let 200 characters through
+    summary = summary.slice(0, 300) + '...';
 
     // if not published, return 404
     if (!mdxSource.frontmatter.published) {
@@ -27,6 +32,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     return {
         props: {
             frontmatter: mdxSource.frontmatter,
+            summary,
             source: mdxSource.source,
             side_bar_data: side_bar_data
         },

--- a/client/src/pages/courses.tsx
+++ b/client/src/pages/courses.tsx
@@ -10,8 +10,12 @@ export const getStaticProps: GetStaticProps = async () => {
     };
 };
 
+import { APPLICATION_METADATA } from '@constants/config';
+
 const Index = ({ posts }: { posts: PostMetadata[] }) => {
-    return <IndexPage posts={posts} />;
+    APPLICATION_METADATA.title = "DN | Courses";
+
+    return <IndexPage posts={posts} meta={APPLICATION_METADATA} />;
 };
 
 export default Index;

--- a/client/src/pages/courses/[slug].tsx
+++ b/client/src/pages/courses/[slug].tsx
@@ -12,10 +12,15 @@ const Post = (props: any) => {
 
 // ----------------------------------------
 import { getMDXSource, getSidebarData } from '@components/pages/post-page/postHelpers';
+import { get_single_post_metadata } from '@utils/markdown/get_post_metadata';
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
     const side_bar_data = getSidebarData(section);
     const mdxSource = await getMDXSource(section, params!.slug as string);
+    let summary: string = get_single_post_metadata(section, params!.slug as string + '.mdx').summary || '';
+
+    // only let 200 characters through
+    summary = summary.slice(0, 300) + '...';
 
     // if not published, return 404
     if (!mdxSource.frontmatter.published) {
@@ -27,6 +32,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     return {
         props: {
             frontmatter: mdxSource.frontmatter,
+            summary,
             source: mdxSource.source,
             side_bar_data: side_bar_data
         },

--- a/client/src/pages/dictionaries/biology/[slug].tsx
+++ b/client/src/pages/dictionaries/biology/[slug].tsx
@@ -14,6 +14,9 @@ import {
     Article, PostContentWrapper
 } from '@components/pages/post';
 
+import { useRouter } from 'next/router';
+import MetaTags from '@components/atomic/MetaTags';
+import { APPLICATION_METADATA, APPLICATION_URL } from '@constants/config';
 import CommentSection from '@components/comments-section/CommentSection';
 
 // ------------------------------------
@@ -115,8 +118,15 @@ const PostPage: React.FC<PostPageProps> = ({ slug, frontmatter, source, side_bar
     // redux control for tag filter visibility
     const tagsFilterVisible = useSelector((state: RootState) => state.visibility.tagsFilterVisible);
 
+    const router = useRouter();
+    const dictionary_display_name: string = frontmatter.dictionary[0].toUpperCase() + frontmatter.dictionary.slice(1);
+    APPLICATION_METADATA.title = `DN | ${dictionary_display_name} - ${frontmatter.word}`;
+    APPLICATION_METADATA.description = `${dictionary_display_name} description, explanation and definition of: ${frontmatter.word}`;
+    APPLICATION_METADATA.url = APPLICATION_URL + router.asPath;
+
     return (
         <>
+            <MetaTags {...APPLICATION_METADATA} />
             <TagFilter
                 tags={all_tags}
                 selectedTags={selectedTags}

--- a/client/src/pages/dictionaries/biology/index.tsx
+++ b/client/src/pages/dictionaries/biology/index.tsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 import { GetStaticProps } from 'next';
 import { MDXRemote } from 'next-mdx-remote';
 
+import MetaTags from '@components/atomic/MetaTags';
+import { APPLICATION_METADATA, APPLICATION_URL } from '@constants/config';
 import TagFilter from '@components/ui/TagFilter';
 import SearchBar from '@components/atomic/SearchBar';
 import SelectDropDown from '@components/atomic/SelectDropDown';
@@ -147,8 +149,13 @@ const DictionaryPage: React.FC<DictionaryPageProps> = ({ sources }) => {
         });
     };
 
+    const router = useRouter()
+    APPLICATION_METADATA.title = 'DN | Biology Dictionary';
+    APPLICATION_METADATA.url = APPLICATION_URL + router.asPath;
+
     return (
         <PostContainer>
+            <MetaTags {...APPLICATION_METADATA} />
             <SideBarContainer>
                 <SideBarSiteName fontSize='20px'>{`Dereck's Notes`}</SideBarSiteName>
                 <SelectDropDown
@@ -213,6 +220,7 @@ import rehypeMathjax from 'rehype-mathjax';
 
 // custom rehype plugins
 import rehypeLinkToDefinition from '@utils/rehype/rehypeLinkToDefinition'; // adds href to word anchor
+import { useRouter } from 'next/router';
 
 export const getStaticProps: GetStaticProps = async () => {
     // get post content and process

--- a/client/src/pages/dictionaries/chemistry/[slug].tsx
+++ b/client/src/pages/dictionaries/chemistry/[slug].tsx
@@ -14,6 +14,9 @@ import {
     Article, PostContentWrapper
 } from '@components/pages/post';
 
+import { useRouter } from 'next/router';
+import MetaTags from '@components/atomic/MetaTags';
+import { APPLICATION_METADATA, APPLICATION_URL } from '@constants/config';
 import CommentSection from '@components/comments-section/CommentSection';
 
 // ------------------------------------
@@ -115,8 +118,15 @@ const PostPage: React.FC<PostPageProps> = ({ slug, frontmatter, source, side_bar
     // redux control for tag filter visibility
     const tagsFilterVisible = useSelector((state: RootState) => state.visibility.tagsFilterVisible);
 
+    const router = useRouter();
+    const dictionary_display_name: string = frontmatter.dictionary[0].toUpperCase() + frontmatter.dictionary.slice(1);
+    APPLICATION_METADATA.title = `DN | ${dictionary_display_name} - ${frontmatter.word}`;
+    APPLICATION_METADATA.description = `${dictionary_display_name} description, explanation and definition of: ${frontmatter.word}`;
+    APPLICATION_METADATA.url = APPLICATION_URL + router.asPath;
+
     return (
         <>
+            <MetaTags {...APPLICATION_METADATA} />
             <TagFilter
                 tags={all_tags}
                 selectedTags={selectedTags}

--- a/client/src/pages/dictionaries/chemistry/index.tsx
+++ b/client/src/pages/dictionaries/chemistry/index.tsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 import { GetStaticProps } from 'next';
 import { MDXRemote } from 'next-mdx-remote';
 
+import MetaTags from '@components/atomic/MetaTags';
+import { APPLICATION_METADATA, APPLICATION_URL } from '@constants/config';
 import TagFilter from '@components/ui/TagFilter';
 import SearchBar from '@components/atomic/SearchBar';
 import SelectDropDown from '@components/atomic/SelectDropDown';
@@ -147,8 +149,13 @@ const DictionaryPage: React.FC<DictionaryPageProps> = ({ sources }) => {
         });
     };
 
+    const router = useRouter()
+    APPLICATION_METADATA.title = 'DN | Chemistry Dictionary';
+    APPLICATION_METADATA.url = APPLICATION_URL + router.asPath;
+
     return (
         <PostContainer>
+            <MetaTags {...APPLICATION_METADATA} />
             <SideBarContainer>
                 <SideBarSiteName fontSize='20px'>{`Dereck's Notes`}</SideBarSiteName>
                 <SelectDropDown
@@ -182,7 +189,7 @@ const DictionaryPage: React.FC<DictionaryPageProps> = ({ sources }) => {
                 <SideBarAbout />
             </SideBarContainer>
             <Article>
-                <h1>Chemistry Dictionary</h1>
+                <h1>Biology Dictionary</h1>
                 <ol>
                     {
                         isClient && renderDefinitions()
@@ -213,6 +220,7 @@ import rehypeMathjax from 'rehype-mathjax';
 
 // custom rehype plugins
 import rehypeLinkToDefinition from '@utils/rehype/rehypeLinkToDefinition'; // adds href to word anchor
+import { useRouter } from 'next/router';
 
 export const getStaticProps: GetStaticProps = async () => {
     // get post content and process

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -10,8 +10,12 @@ export const getStaticProps: GetStaticProps = async () => {
     };
 };
 
+import { APPLICATION_METADATA } from '@constants/config';
+
 const Index = ({ posts }: { posts: PostMetadata[] }) => {
-    return <IndexPage posts={posts} />;
+    APPLICATION_METADATA.title = "DN | Blog";
+
+    return <IndexPage posts={posts} meta={APPLICATION_METADATA} />;
 };
 
 export default Index;

--- a/client/src/pages/myaccount.tsx
+++ b/client/src/pages/myaccount.tsx
@@ -18,6 +18,9 @@ import ProfileImage from '@components/pages/myaccount/ProfileImage';
 import Comment from '@components/comments-section/Comment';
 import ChangePassword from '@components/pages/myaccount/ChangePassword';
 
+import MetaTags from '@components/atomic/MetaTags';
+import { APPLICATION_METADATA, APPLICATION_URL } from '@constants/config';
+
 import api_me from '@utils/api/auth/me';
 import api_update_user_info from '@utils/api/interact/update_user_info';
 import get_comments_threads_by_id from '@utils/api/interact/get_comments_threads_by_id';
@@ -141,8 +144,14 @@ const Account: React.FC = () => {
         // }
     };
 
+    APPLICATION_METADATA.title = `DN | My Account`;
+    APPLICATION_METADATA.description = `DN | ${userData.user.username}'s account page`;
+    APPLICATION_METADATA.url = APPLICATION_URL + router.asPath;
+
     return (
         <PostContainer>
+            <MetaTags {...APPLICATION_METADATA} />
+
             <SideBarContainer>
                 <SideBarSiteName fontSize='20px'>{`Dereck's Notes`}</SideBarSiteName>
                 <SideBarAbout />

--- a/client/src/pages/references.tsx
+++ b/client/src/pages/references.tsx
@@ -10,8 +10,12 @@ export const getStaticProps: GetStaticProps = async () => {
     };
 };
 
+import { APPLICATION_METADATA } from '@constants/config';
+
 const Index = ({ posts }: { posts: PostMetadata[] }) => {
-    return <IndexPage posts={posts} />;
+    APPLICATION_METADATA.title = "DN | References";
+
+    return <IndexPage posts={posts} meta={APPLICATION_METADATA} />;
 };
 
 export default Index;

--- a/client/src/pages/references/[slug].tsx
+++ b/client/src/pages/references/[slug].tsx
@@ -12,10 +12,15 @@ const Post = (props: any) => {
 
 // ----------------------------------------
 import { getMDXSource, getSidebarData } from '@components/pages/post-page/postHelpers';
+import { get_single_post_metadata } from '@utils/markdown/get_post_metadata';
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
     const side_bar_data = getSidebarData(section);
     const mdxSource = await getMDXSource(section, params!.slug as string);
+    let summary: string = get_single_post_metadata(section, params!.slug as string + '.mdx').summary || '';
+
+    // only let 200 characters through
+    summary = summary.slice(0, 300) + '...';
 
     // if not published, return 404
     if (!mdxSource.frontmatter.published) {
@@ -27,6 +32,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     return {
         props: {
             frontmatter: mdxSource.frontmatter,
+            summary,
             source: mdxSource.source,
             side_bar_data: side_bar_data
         },

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -9,7 +9,7 @@ dotenv.config({ path: '../.env' });
 
 
 const middleware = (getDefaultMiddleware: any) => {
-    if (process.env.REDUX_LOGGER) {
+    if (process.env.REDUX_LOGGER === 'true') {
         return getDefaultMiddleware().concat(thunk, logger);
     } else {
         return getDefaultMiddleware().concat(thunk);

--- a/client/src/utils/markdown/get_post_metadata.ts
+++ b/client/src/utils/markdown/get_post_metadata.ts
@@ -12,6 +12,69 @@ import remarkMath from 'remark-math';
 
 import { visit } from 'unist-util-visit';
 
+export function get_single_post_metadata(folder: string, file_name: string): PostMetadata {
+    try {
+        // if file_name doesn't end with .mdx; throw error
+        if (!file_name.endsWith('.mdx')) {
+            throw new Error(`File name must end with .mdx: ${file_name}`);
+        }
+        const file: string = path.join(ROOT, 'content', folder, file_name);
+        const file_contents: string = fs.readFileSync(file, 'utf8');
+        const { data, content } = matter(file_contents) as matter.GrayMatterFile<string>;
+
+        const parsedContent = remark()
+            .use(remarkGfm)
+            .use(remarkMath)
+            .use(mdx)
+            .use(strip)
+            .parse(content);
+
+        // Extract text from paragraph nodes
+        const paragraphs: string[] = [];
+        visit(parsedContent, 'paragraph', (node: any) => {
+            const textContent = node.children
+                .map((child: any) => {
+                    if (child.value) {
+                        return child.value.trim();
+                    }
+                })
+                .join('');
+
+            if (textContent.trim() !== '') {
+                paragraphs.push(textContent);
+            }
+        });
+
+        // process to html and then to string
+        const summary = remark()
+            .processSync(paragraphs.join(' '))
+            .toString()
+            .trim();
+
+        return {
+            slug: file_name.replace('.mdx', ''),
+            section: folder,
+
+            title: data.title,
+            blurb: data.blurb,
+            coverImage: `/site-images/card-covers/${data.coverImage}.png`,
+            author: data.author,
+            date: typeof data.date === 'string' ? data.date : data.date.toISOString().split('T')[0],
+
+            summary: summary,
+
+            tags: data.tags,
+
+            published: data.published,
+            subtitle: data.subtitle ? data.subtitle : '',
+        };
+    } catch (error: any) {
+        console.error(`Error processing file: ${file_name}`);
+        console.error(error);
+        process.exit(1);
+    }
+}
+
 // NOTE: func used in getStaticProps
 // props are passed to IndexPage as PostMetadata[]
 //    IndexPage uses: tags, slug
@@ -23,72 +86,6 @@ export default function get_post_metadata(folder: string): PostMetadata[] {
     const md = files.filter((fn) => fn.endsWith('.mdx'));
 
     return md.map((file_name) => {
-        try {
-            const file: string = path.join(ROOT, 'content', folder, file_name);
-            const file_contents: string = fs.readFileSync(file, 'utf8');
-            const { data, content } = matter(file_contents) as matter.GrayMatterFile<string>;
-
-            const parsedContent = remark()
-                .use(remarkGfm)
-                .use(remarkMath)
-                .use(mdx)
-                .use(strip)
-                .parse(content);
-
-            // Extract text from paragraph nodes
-            const paragraphs: string[] = [];
-            visit(parsedContent, 'paragraph', (node: any) => {
-                const textContent = node.children
-                    // .filter((child: any) => {
-                    //     // if value starts with a pipe, it's a table
-                    //     // if (/\|/.test(child.value)) return false;
-                    //     return true;
-                    // })
-                    .map((child: any) => {
-                        // if child.value
-                        if (child.value) {
-                            return child.value
-                                // .replace(/\[\^\d+\]:?/g, '') // footnotes [^1]
-                                // .replace(/^\[( |x)\]/g, '') // task lists * [ ]
-                                // .replace(/~{1,2}/g, '') // strikethrough ~ 1 or 2 ~~
-                                .trim();
-                        }
-                    })
-                    .join('');
-
-                if (textContent.trim() !== '') {
-                    paragraphs.push(textContent);
-                }
-            });
-
-            // process to html and then to string
-            const summary = remark()
-                .processSync(paragraphs.join(' '))
-                .toString()
-                .trim();
-
-            return {
-                slug: file_name.replace('.mdx', ''),
-                section: folder,
-
-                title: data.title,
-                blurb: data.blurb,
-                coverImage: `/site-images/card-covers/${data.coverImage}.png`,
-                author: data.author,
-                // to date format YYYT-MM-DD HH:MM:SS
-                date: typeof data.date === 'string' ? data.date : data.date.toISOString().split('T')[0],
-
-                summary: summary,
-
-                tags: data.tags,
-
-                published: data.published,
-                subtitle: data.subtitle ? data.subtitle : '',
-            };
-        } catch (error: any) {
-            console.error(`Error processing file: ${file_name}`);
-            console.error(error);
-            process.exit(1);
-        }
+        return get_single_post_metadata(folder, file_name);
     });
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,7 +28,7 @@ const redisStore = makeRedisStore(session);
 // ----------------------------------------
 export const app = express();
 
-if (process.env.DEV_MODE) {
+if (process.env.DEV_MODE === 'true') {
     // assuming frontend on port 3000
     app.use(cors({ origin: 'http://localhost:3000', credentials: true }));
     console.log('CORS enabled for localhost:3000');
@@ -50,7 +50,7 @@ export async function SetUp(dbConnector: DatabaseConnector): Promise<void> {
             resave: false, // forces session be saved back to the session store, even if the session was never modified during the request
             saveUninitialized: false,
             cookie: {
-                secure: !Boolean(process.env.DEV_MODE), // HTTPS in production
+                secure: !(process.env.DEV_MODE === 'true'), // HTTPS in production
                 httpOnly: false, // true, // cookie inaccessible from JavaScript running in the browser
                 // days * hours * minutes * seconds * milliseconds
                 maxAge: 30 * 24 * 60 * 60 * 1000 // 1 day in milliseconds
@@ -87,7 +87,7 @@ export async function main(): Promise<void> {
 
     app.listen(PORT, () => {
         console.log(`Server listening on port ${PORT}`);
-        let API_LISTENING_ON: string = process.env.DEV_MODE ? 'https://derecksnotes.com' : 'http://localhost:3003';
+        let API_LISTENING_ON: string = process.env.DEV_MODE === 'true' ? 'http://localhost:3003' : 'https://derecksnotes.com';
         console.log(`API listening on ${API_LISTENING_ON + API_PREFIX}`);
     });
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,7 +28,7 @@ const redisStore = makeRedisStore(session);
 // ----------------------------------------
 export const app = express();
 
-if (process.env.DEV_MODE === 'true') {
+if (process.env.NEXT_PUBLIC_DEV_MODE === 'true') {
     // assuming frontend on port 3000
     app.use(cors({ origin: 'http://localhost:3000', credentials: true }));
     console.log('CORS enabled for localhost:3000');
@@ -50,7 +50,7 @@ export async function SetUp(dbConnector: DatabaseConnector): Promise<void> {
             resave: false, // forces session be saved back to the session store, even if the session was never modified during the request
             saveUninitialized: false,
             cookie: {
-                secure: !(process.env.DEV_MODE === 'true'), // HTTPS in production
+                secure: !(process.env.NEXT_PUBLIC_DEV_MODE === 'true'), // HTTPS in production
                 httpOnly: false, // true, // cookie inaccessible from JavaScript running in the browser
                 // days * hours * minutes * seconds * milliseconds
                 maxAge: 30 * 24 * 60 * 60 * 1000 // 1 day in milliseconds
@@ -78,7 +78,7 @@ export async function SetUp(dbConnector: DatabaseConnector): Promise<void> {
 }
 
 export async function main(): Promise<void> {
-    // const uri: string = process.env.MONGO_URI + (process.env.DEV_MODE ? 'derecksnotes_test' : 'derecksnotes');
+    // const uri: string = process.env.MONGO_URI + (process.env.NEXT_PUBLIC_DEV_MODE ? 'derecksnotes_test' : 'derecksnotes');
     const uri: string = process.env.MONGO_URI + 'derecksnotes_test'; // running next.derecksnotes.com test server so hard coded
     const dbConnector = new MongoDBConnector(uri);
     console.log(`Connecting to MongoDB at ${uri}`);
@@ -87,7 +87,7 @@ export async function main(): Promise<void> {
 
     app.listen(PORT, () => {
         console.log(`Server listening on port ${PORT}`);
-        let API_LISTENING_ON: string = process.env.DEV_MODE === 'true' ? 'http://localhost:3003' : 'https://derecksnotes.com';
+        let API_LISTENING_ON: string = process.env.NEXT_PUBLIC_DEV_MODE === 'true' ? 'http://localhost:3003' : 'https://derecksnotes.com';
         console.log(`API listening on ${API_LISTENING_ON + API_PREFIX}`);
     });
 }

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
 dotenv.config({ path: path.join(__dirname, '..', '..', '..', '.env') });
@@ -8,9 +9,14 @@ export function DATETIME_YYYY_MM_DD_HHMMSS(): string {
 
 export const ROOT_DIR_CLIENT: string = path.join(__dirname, '..', '..', '..', 'client');
 
-export const ROOT_DIR_CLIENT_UPLOADS: string = path.join(ROOT_DIR_CLIENT, (!process.env.DEV_MODE ? 'public' : 'out'), 'site-images', 'uploads', 'profile-photos');
+export const ROOT_DIR_CLIENT_UPLOADS: string = path.join(ROOT_DIR_CLIENT, (process.env.DEV_MODE === 'true' ? 'public' : 'out'), 'site-images', 'uploads', 'profile-photos');
+
+// if ROOT_DIR_CLIENT_UPLOADS does not exist, create it; do it recursively
+if (!fs.existsSync(ROOT_DIR_CLIENT_UPLOADS)) {
+    fs.mkdirSync(ROOT_DIR_CLIENT_UPLOADS, { recursive: true });
+}
 
 // if in prod nginx picks up requests to /api/v3 and forwards to server
-export const API_PREFIX: string = process.env.DEV_MODE ? '' : '/api/v3';
+export const API_PREFIX: string = process.env.DEV_MODE === 'true' ? '/api/v3' : '';
 
 export const MAX_COMMENT_DEPTH: number = 5;

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -9,7 +9,7 @@ export function DATETIME_YYYY_MM_DD_HHMMSS(): string {
 
 export const ROOT_DIR_CLIENT: string = path.join(__dirname, '..', '..', '..', 'client');
 
-export const ROOT_DIR_CLIENT_UPLOADS: string = path.join(ROOT_DIR_CLIENT, (process.env.DEV_MODE === 'true' ? 'public' : 'out'), 'site-images', 'uploads', 'profile-photos');
+export const ROOT_DIR_CLIENT_UPLOADS: string = path.join(ROOT_DIR_CLIENT, (process.env.NEXT_PUBLIC_DEV_MODE === 'true' ? 'public' : 'out'), 'site-images', 'uploads', 'profile-photos');
 
 // if ROOT_DIR_CLIENT_UPLOADS does not exist, create it; do it recursively
 if (!fs.existsSync(ROOT_DIR_CLIENT_UPLOADS)) {
@@ -17,6 +17,6 @@ if (!fs.existsSync(ROOT_DIR_CLIENT_UPLOADS)) {
 }
 
 // if in prod nginx picks up requests to /api/v3 and forwards to server
-export const API_PREFIX: string = process.env.DEV_MODE === 'true' ? '/api/v3' : '';
+export const API_PREFIX: string = process.env.NEXT_PUBLIC_DEV_MODE === 'true' ? '/api/v3' : '';
 
 export const MAX_COMMENT_DEPTH: number = 5;


### PR DESCRIPTION
1. Create `MetaTags` component so that pages can be enriched for social sharing[^1].
2. Broke apart `get_post_metadata` into single post and all post functions; save some computation if I only want one. Used for creating description in `MetaTags` for posts.
3. Had to change `.env` to use `NEXT_PUBLIC_` prefix so that `DEV_MODE` env variable could be used on front end.

![Screenshot 2023-10-19 at 20 52 04](https://github.com/dereckmezquita/derecksnotes.com/assets/44912288/4ded8474-f573-4253-a596-72772c84431f)

[^1]: https://amprandom.blogspot.com/2016/12/blogger-whatsapp-rich-link-preview.html