### PR TITLE
Account & content hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,11 @@
 # derecksnotes.com
 # Copy to .env and fill in values.
 
-# Environment: local | dev | prod
-# All URLs, domains, and behavior derive from this single value.
-BUILD_ENV=local
+# APP_ENV (local | dev | prod) is the single source of truth for which
+# deployment this is. All URLs, domains, and behavior derive from it.
+# NOTE: NODE_ENV is owned by Next.js (development from `next dev`, production
+# from `next build` / `next start`) — do not set it manually.
+APP_ENV=local
 
 # Session signing key. Generate with: openssl rand -base64 32
 SESSION_SECRET=

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -39,7 +39,26 @@ jobs:
           echo "env=$ENV" >> $GITHUB_OUTPUT
           echo "max_backups=$MAX" >> $GITHUB_OUTPUT
 
+      - name: Checkout backup script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/backup-db.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Copy backup script to VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.REMOTE_HOST }}
+          username: ${{ secrets.REMOTE_USERNAME }}
+          password: ${{ secrets.REMOTE_PASSWORD }}
+          port: ${{ secrets.REMOTE_PORT }}
+          source: scripts/backup-db.sh
+          target: /tmp/derecksnotes-backup/
+
       - name: Run backup
+        # Invoke the canonical scripts/backup-db.sh (single source of truth).
+        # I10: the previous inline duplicate of the script silently diverged
+        # from scripts/backup-db.sh; fixes had to be remembered in two places.
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.REMOTE_HOST }}
@@ -48,33 +67,14 @@ jobs:
           port: ${{ secrets.REMOTE_PORT }}
           command_timeout: 10m
           script: |
+            set -euo pipefail
             DOMAIN="${{ steps.vars.outputs.domain }}"
             DB_PATH="/var/www/${DOMAIN}/data/database.sqlite"
             BACKUP_DIR="/var/www/${DOMAIN}/backups"
             MAX_BACKUPS="${{ steps.vars.outputs.max_backups }}"
 
-            if [ ! -f "$DB_PATH" ]; then
-              echo "Database not found: $DB_PATH"
-              exit 1
-            fi
+            chmod +x /tmp/derecksnotes-backup/scripts/backup-db.sh
+            /tmp/derecksnotes-backup/scripts/backup-db.sh "$DB_PATH" "$BACKUP_DIR" "$MAX_BACKUPS"
 
-            mkdir -p "$BACKUP_DIR"
-            TIMESTAMP=$(date +"%Y-%m-%d-%H%M")
-            BACKUP="${BACKUP_DIR}/db-${TIMESTAMP}.sqlite"
-
-            echo "Backing up: $DB_PATH"
-            sqlite3 "$DB_PATH" ".backup '${BACKUP}'"
-            gzip "$BACKUP"
-            echo "Created: db-${TIMESTAMP}.sqlite.gz"
-
-            # Rotate — keep last N backups
-            BACKUP_COUNT=$(find "$BACKUP_DIR" -name "db-*.sqlite.gz" -type f | wc -l)
-            if [ "$BACKUP_COUNT" -gt "$MAX_BACKUPS" ]; then
-              DELETE_COUNT=$((BACKUP_COUNT - MAX_BACKUPS))
-              echo "Rotating: removing ${DELETE_COUNT} old backup(s)..."
-              find "$BACKUP_DIR" -name "db-*.sqlite.gz" -type f -printf '%T@ %p\n' \
-                | sort -n | head -n "$DELETE_COUNT" | cut -d' ' -f2- | xargs rm -f
-            fi
-
-            REMAINING=$(find "$BACKUP_DIR" -name "db-*.sqlite.gz" -type f | wc -l)
-            echo "Done. ${REMAINING} backup(s) in ${BACKUP_DIR}"
+            # Cleanup
+            rm -rf /tmp/derecksnotes-backup

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.image_tag }}
           build-args: |
-            BUILD_ENV=${{ steps.vars.outputs.environment }}
+            APP_ENV=${{ steps.vars.outputs.environment }}
             COMMIT_SHA=${{ github.sha }}
 
   deploy:
@@ -140,7 +140,7 @@ jobs:
               "CONTAINER_NAME=${{ steps.vars.outputs.container_name }}" \
               "PORT_CLIENT=${{ steps.vars.outputs.port_client }}" \
               "PORT_SERVER=${{ steps.vars.outputs.port_server }}" \
-              "BUILD_ENV=${{ env.ENV }}" \
+              "APP_ENV=${{ env.ENV }}" \
               "COMMIT_SHA=${{ github.sha }}" \
               "SESSION_SECRET=${{ secrets.SESSION_SECRET }}" \
               "DATA_PATH=${{ steps.vars.outputs.data_path }}" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Typecheck + bun test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.2'
+
+      - name: Install workspace deps
+        run: bun install --frozen-lockfile
+
+      # I29: regression-protect every fix in this PR. The repo currently has
+      # 26 tests across client + server; CI didn't run them before this
+      # workflow.
+      - name: Client typecheck
+        run: cd client && bun run typecheck
+
+      - name: Server typecheck
+        run: cd server && bunx tsc --noEmit
+
+      - name: Client tests
+        run: cd client && bun test
+
+      - name: Server tests
+        run: cd server && bun test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
   test:
     name: Typecheck + bun test
     runs-on: ubuntu-latest
+    env:
+      # APP_ENV=local is the default but spell it out so the [env] warning
+      # doesn't clutter the CI log. SESSION_SECRET is satisfied by the
+      # local-dev placeholder branch in server/src/lib/env.ts.
+      APP_ENV: local
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-secrets.yml
+++ b/.github/workflows/update-secrets.yml
@@ -58,7 +58,7 @@ jobs:
               "CONTAINER_NAME=${{ steps.vars.outputs.container_name }}" \
               "PORT_CLIENT=${{ steps.vars.outputs.port_client }}" \
               "PORT_SERVER=${{ steps.vars.outputs.port_server }}" \
-              "BUILD_ENV=${{ inputs.environment }}" \
+              "APP_ENV=${{ inputs.environment }}" \
               "SESSION_SECRET=${{ secrets.SESSION_SECRET }}" \
               "DATA_PATH=${{ steps.vars.outputs.data_path }}" \
               "PUBLIC_PATH=${{ steps.vars.outputs.public_path }}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,11 +47,6 @@ FROM oven/bun:1.2-slim AS production
 
 RUN apt-get update && apt-get install -y --no-install-recommends tini curl && rm -rf /var/lib/apt/lists/*
 
-# Pin NODE_ENV=production so next-mdx-remote and react/jsx-runtime agree on
-# which JSX helper to use; without this the on-demand RSC MDX path crashes
-# under Bun. See entrypoint.sh for the runtime explanation.
-ENV NODE_ENV=production
-
 WORKDIR /app
 
 # Copy root package.json for version reading

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,23 @@ COPY client/ client/
 RUN rm -rf client/.next
 
 # Build arguments
-ARG BUILD_ENV=prod
+ARG APP_ENV=prod
 ARG COMMIT_SHA=local
 
-ENV BUILD_ENV=${BUILD_ENV}
+# APP_ENV is read by the server. NEXT_PUBLIC_APP_ENV is inlined into the client
+# bundle by Next.js (the NEXT_PUBLIC_ prefix is the framework convention for
+# build-time exposure to browser code).
+ENV APP_ENV=${APP_ENV}
+ENV NEXT_PUBLIC_APP_ENV=${APP_ENV}
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
+
+# NODE_ENV is owned by Next.js (development | production). Pin it to production
+# at build time so Webpack inlines the production code path through
+# next-mdx-remote (whose serialize.js bakes `development: ...` from
+# process.env.NODE_ENV into the compiled MDX). Without this, on-demand MDX
+# rendering crashes because the compiled body expects _jsxDEV but the runtime
+# loads the production jsx-runtime.
+ENV NODE_ENV=production
 
 WORKDIR /app/client
 RUN bun run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,11 @@ FROM oven/bun:1.2-slim AS production
 
 RUN apt-get update && apt-get install -y --no-install-recommends tini curl && rm -rf /var/lib/apt/lists/*
 
+# Pin NODE_ENV=production so next-mdx-remote and react/jsx-runtime agree on
+# which JSX helper to use; without this the on-demand RSC MDX path crashes
+# under Bun. See entrypoint.sh for the runtime explanation.
+ENV NODE_ENV=production
+
 WORKDIR /app
 
 # Copy root package.json for version reading

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,59 @@
 # derecksnotes.com Change Log
 
+## v6.2.0 - Account & Content Hardening (2026-06)
+
+A research-backed pass over the account, comment, and moderation surface plus a usable admin moderation queue.
+
+### Security
+
+- **Session tokens hashed at rest**: the DB now stores `SHA-256` (or `HMAC-SHA256` with optional `SESSION_TOKEN_PEPPER`) of the cookie value, not the raw token. A read-only DB leak can no longer resume any live session.
+- **CSRF defence-in-depth** on `/api/v1`: rejects mutating requests whose `Sec-Fetch-Site` is `none`/`cross-site` and whose `Origin`/`Referer` is not in the allowlist. `GET`/`HEAD`/`OPTIONS` unaffected.
+- **Login enumeration** killed: a precomputed dummy bcrypt round runs on every failed login, so the response time no longer leaks whether a username exists.
+- **Register enumeration** mitigated: email conflict now returns a generic refusal instead of "Email already registered" (TODO: switch to the Mozilla send-on-conflict pattern once an email sender is wired up).
+- **Comment edit history** is no longer public: gated on `authenticate()` and visible only to the author or moderators with `comment.view.unapproved`.
+- **SSE `/api/v1/graph/live`** authenticated, per-user + per-IP connection caps, explicit `node:crypto` import.
+- **`ADMIN_USERNAME` bootstrap**: matching registration is auto-elevated to admin so fresh prod is never locked out; loud warning on non-local deploys when the var is empty.
+- **Password length / 72-byte bcrypt truncation**: `hashPassword` / `verifyPassword` pre-hash with NFC-normalised SHA-256 → base64 so the full passphrase contributes entropy regardless of length.
+- **Moderator boundary**: `user.ban` callers cannot ban admins (unless they themselves are admin), themselves, or the last remaining admin; can't stack a second ban while one is active.
+- **Per-route rate limits** on password change (bcrypt CPU pin), account delete, bulk operations, and all `/admin/*` writes.
+- **Audit log auth events**: register, login, logout, password change, account delete now log to `auditLog`.
+- **Logout idempotency**: clears the cookie even if no live session — no more 401 on expired-cookie logout.
+
+### Comment correctness
+
+- **N+1 fixed**: `formatCommentTree` was ~800 SQLite round-trips per 20-row page (per-node count + per-node fetch). Replaced with a single BFS sweep + in-memory grouping. Single-digit query count, same output.
+- **Soft-deleted top-level comments** no longer consume slots / inflate `total` in the page response.
+- **Stable pagination**: `orderBy` gained an `asc(id)` tiebreaker so offset pages can't repeat or skip rows when timestamps collide.
+- **Reaction toggle race**: `reactToComment` read-modify-write wrapped in `db.transaction()`.
+- **Typed errors**: `CommentValidationError` / `NotFoundError` / `AuthError` replace the fragile `error.stack?.includes('at')` heuristic that silently coerced every business error to 500.
+- **Bulk-delete fix**: previously did `N` statements and mis-reported `deleted` as the input length; now a single `inArray` UPDATE with `.returning`.
+
+### Admin moderation queue
+
+- Pending Comments tab is now a rich table with per-author reputation columns: account age, history (approved / rejected / pending), karma (likes minus dislikes received), groups, per-comment reactions, and a flavour badge per row (`admin`, `moderator`, `trusted`, `brand new`, `first comment`, `has rejections`, `clean history`, `unranked`).
+- **Shift-click multi-select**: click a checkbox, shift-click another row → toggles every row in between to the new target state. Header checkbox is indeterminate on partial selection.
+- Bulk Approve / Bulk Reject wired to the existing transactional endpoints.
+- Author-facing pending badge now reads `pending review — only visible to you` with a tooltip explaining the auto-approve threshold.
+
+### Reusable UI primitives
+
+- `DataTable`, `DataTableWrapper`, `DataTableCheckbox`, `SelectAllCheckbox` extracted as the canonical styled table for the codebase.
+- `useRangeSelect<T>(items)` hook — id-keyed multi-select with shift-click range semantics; reusable across any selectable list.
+- `BulkActionBar` toolbar component that renders nothing when count is 0, with a built-in Clear button.
+- `UsersTab` refactored to use the hook — gains shift-click for free.
+
+### Backup hardening
+
+- `scripts/backup-db.sh` runs `PRAGMA integrity_check` + `PRAGMA foreign_key_check` before gzip and `gunzip -t` after; any failure removes the bad artefact and exits non-zero so the rotation can't silently drop the last known-good copy.
+- `.github/workflows/backup-db.yml` now scp's the script to the VPS and invokes it instead of inlining a duplicate (single source of truth).
+
+### Convention & infrastructure
+
+- **`BUILD_ENV` → `APP_ENV`** across server, client (`NEXT_PUBLIC_APP_ENV`), Dockerfile, docker-compose, CI workflows, and `.env` examples — following the [Next.js docs convention](https://nextjs.org/docs/messages/non-standard-node-env) and mirroring Vercel's own `NODE_ENV` + `VERCEL_ENV` split. `NODE_ENV=production` pinned at Docker build time so Webpack inlines the production code path through `next-mdx-remote`.
+- **MDX 500 fix**: dictionary `[slug]/page.tsx` now pre-builds every MDX file on dev too. The dev "slice(0,3) + dynamicParams" split was leaving the rest to an on-demand RSC compile that crashes inside `@mdx-js/mdx`'s `recma-jsx-rewrite` under Bun. Regression test (12 cases) blocks reintroduction.
+- **CI**: new `test.yml` workflow runs client + server typecheck and `bun test` on push and PRs (28/28 green).
+- **Security spike** documented at `docs/spikes/2026-06-18-security-fix-research.md` — current best practices for session storage, account enumeration defences, rate-limit budgets, CSRF in 2026, password hashing edge cases, SSE security, SQLite backup durability, and Drizzle transactions. Reference for the implementations above.
+
 ## v6.1.0 - Knowledge Graph & Content Rendering Fixes (2026-06)
 
 A WebGL knowledge-graph view of the whole corpus, dictionary UI cleanup, and a batch of MDX rendering fixes.

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,9 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@happy-dom/global-registrator": "^20.10.6",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/js-yaml": "^4.0.9",
         "@types/marked": "^5.0.2",
         "@types/node": "^20",
@@ -61,6 +64,8 @@
         "@types/styled-components": "^5.1.34",
         "eslint": "^9",
         "eslint-config-next": "15.1.3",
+        "happy-dom": "^20.10.6",
+        "react-test-renderer": "^19.2.7",
         "typescript": "^5",
       },
     },
@@ -104,6 +109,8 @@
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -204,6 +211,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -351,7 +360,13 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/bcrypt": ["@types/bcrypt@6.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ=="],
 
@@ -429,7 +444,11 @@
 
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/type-utils": "8.58.0", "@typescript-eslint/utils": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg=="],
 
@@ -515,7 +534,7 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
@@ -564,6 +583,8 @@
     "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
@@ -685,6 +706,8 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
     "dotenv": ["dotenv@17.4.0", "", {}, "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ=="],
@@ -703,7 +726,7 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
 
@@ -856,6 +879,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1054,6 +1079,8 @@
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "lucide-react": ["lucide-react@0.469.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
@@ -1319,6 +1346,8 @@
 
     "prettier": ["prettier@3.7.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
@@ -1345,7 +1374,9 @@
 
     "react-icons": ["react-icons@5.6.0", "", { "peerDependencies": { "react": "*" } }, "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA=="],
 
-    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+    "react-is": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.7", "", { "dependencies": { "react-is": "^19.2.7", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -1647,7 +1678,7 @@
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
@@ -1671,7 +1702,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -1719,6 +1750,8 @@
 
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
+    "data-urls/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -1726,6 +1759,8 @@
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-import/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "eslint-plugin-jsx-a11y/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1736,6 +1771,12 @@
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "gray-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "jsdom/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "jsdom/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "mdast-util-definitions/@types/mdast": ["@types/mdast@3.0.15", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ=="],
 
@@ -1750,6 +1791,14 @@
     "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "remark-external-links/@types/hast": ["@types/hast@2.3.10", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw=="],
 

--- a/client/bunfig.toml
+++ b/client/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test/happy-dom.ts"]

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -4,13 +4,11 @@ const nextConfig: NextConfig = {
   compiler: {
     styledComponents: true
   },
-  env: {
-    BUILD_ENV: process.env.BUILD_ENV || 'local'
-  },
   async rewrites() {
     // Only proxy API calls in local development
     // In dev/prod, nginx handles routing
-    if (process.env.BUILD_ENV === 'local' || !process.env.BUILD_ENV) {
+    const appEnv = process.env.NEXT_PUBLIC_APP_ENV;
+    if (appEnv === 'local' || !appEnv) {
       return [
         {
           source: '/api/:path*',

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,9 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@happy-dom/global-registrator": "^20.10.6",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/js-yaml": "^4.0.9",
     "@types/marked": "^5.0.2",
     "@types/node": "^20",
@@ -53,6 +56,8 @@
     "@types/styled-components": "^5.1.34",
     "eslint": "^9",
     "eslint-config-next": "15.1.3",
+    "happy-dom": "^20.10.6",
+    "react-test-renderer": "^19.2.7",
     "typescript": "^5"
   }
 }

--- a/client/src/app/admin/page.tsx
+++ b/client/src/app/admin/page.tsx
@@ -237,14 +237,132 @@ function OverviewTab() {
 // Comments Moderation
 // ============================================================================
 
+// ── Pending Comments: rich table + shift-click multi-select ────────────────
+//
+// Reputation columns surface the cursory information an admin needs without
+// having to click into the user's profile. Shift-click on a checkbox selects
+// the range from the last clicked row to the current row (toggling all of
+// them to the current row's new state) — the standard table-multiselect
+// keyboard convention.
+
+const PendingTableWrapper = styled.div`
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+`;
+
+const PendingTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  font-family: ${(p) => p.theme.text.font.roboto};
+
+  th,
+  td {
+    padding: 6px 8px;
+    text-align: left;
+    border-bottom: 1px solid ${(p) => p.theme.container.border.colour.primary()};
+    vertical-align: top;
+  }
+
+  th {
+    font-weight: ${(p) => p.theme.text.weight.bold};
+    color: ${(p) => p.theme.text.colour.light_grey()};
+    text-transform: uppercase;
+    font-size: 0.65rem;
+    letter-spacing: 0.05em;
+    border-bottom: 2px solid ${(p) => p.theme.text.colour.header()};
+    white-space: nowrap;
+  }
+
+  tbody tr.selected {
+    background: ${(p) => p.theme.text.colour.header()}10;
+  }
+
+  td .content-preview {
+    max-width: 340px;
+    color: ${(p) => p.theme.text.colour.primary()};
+    line-height: 1.35;
+  }
+
+  td .meta {
+    color: ${(p) => p.theme.text.colour.light_grey()};
+    font-size: 0.7rem;
+  }
+`;
+
+const TableCheckbox = styled.input.attrs({ type: 'checkbox' })`
+  cursor: pointer;
+  /* Big hit area so shift-clicking on a fiddly checkbox isn't a sniper shot. */
+  width: 16px;
+  height: 16px;
+`;
+
+const InlineActions = styled.div`
+  display: flex;
+  gap: 4px;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+`;
+
+const MiniButton = styled.button<{ $variant?: 'approve' | 'reject' }>`
+  font-family: ${(p) => p.theme.text.font.roboto};
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid ${(p) => (p.$variant === 'reject' ? '#c62828' : '#0F9960')};
+  background: ${(p) =>
+    p.$variant === 'reject' ? 'rgba(198,40,40,0.08)' : 'rgba(15,153,96,0.08)'};
+  color: ${(p) => (p.$variant === 'reject' ? '#c62828' : '#0F9960')};
+  &:hover {
+    background: ${(p) =>
+      p.$variant === 'reject'
+        ? 'rgba(198,40,40,0.18)'
+        : 'rgba(15,153,96,0.18)'};
+  }
+`;
+
+const Sparkline = styled.span`
+  font-family: ${(p) => p.theme.text.font.roboto};
+  white-space: nowrap;
+`;
+
+function reputationFlavour(c: AdminPendingComment): {
+  label: string;
+  colour: string;
+} {
+  if (c.authorGroups.includes('admin'))
+    return { label: 'admin', colour: '#c62828' };
+  if (c.authorGroups.includes('moderator'))
+    return { label: 'moderator', colour: '#106BA3' };
+  if (c.authorGroups.includes('trusted'))
+    return { label: 'trusted', colour: '#0F9960' };
+  if (c.authorAccountAgeDays < 1)
+    return { label: 'brand new', colour: '#c62828' };
+  if (c.authorTotalComments <= 1)
+    return { label: 'first comment', colour: '#996f0f' };
+  if (
+    c.authorRejectedCount > 0 &&
+    c.authorRejectedCount >= c.authorApprovedCount
+  )
+    return { label: 'has rejections', colour: '#c62828' };
+  if (c.authorApprovedCount >= 5 && c.authorRejectedCount === 0)
+    return { label: 'clean history', colour: '#0F9960' };
+  return { label: 'unranked', colour: '#999' };
+}
+
 function CommentsTab() {
   const [comments, setComments] = useState<AdminPendingComment[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  // Index of the last checkbox-clicked row. Shift-click reads this to compute
+  // the range. Reset on data reloads so we can't anchor to a now-stale row.
+  const [anchorIdx, setAnchorIdx] = useState<number | null>(null);
 
   useEffect(() => {
     load(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const load = async (p: number) => {
@@ -254,12 +372,21 @@ function CommentsTab() {
     setComments(p === 1 ? data.data : [...comments, ...data.data]);
     setHasMore(data.hasMore);
     setPage(p);
+    setAnchorIdx(null);
   };
+
+  const removeFromList = (ids: string[]) =>
+    setComments((prev) => prev.filter((c) => !ids.includes(c.id)));
 
   const approve = async (id: string) => {
     try {
       await api.post(`/admin/comments/${id}/approve`);
-      setComments((prev) => prev.filter((c) => c.id !== id));
+      removeFromList([id]);
+      setSelected((prev) => {
+        const n = new Set(prev);
+        n.delete(id);
+        return n;
+      });
       toast.success('Comment approved');
     } catch {
       toast.error('Failed to approve');
@@ -269,7 +396,12 @@ function CommentsTab() {
   const reject = async (id: string) => {
     try {
       await api.post(`/admin/comments/${id}/reject`);
-      setComments((prev) => prev.filter((c) => c.id !== id));
+      removeFromList([id]);
+      setSelected((prev) => {
+        const n = new Set(prev);
+        n.delete(id);
+        return n;
+      });
       toast.success('Comment rejected');
     } catch {
       toast.error('Failed to reject');
@@ -277,45 +409,83 @@ function CommentsTab() {
   };
 
   const bulkApprove = async () => {
+    if (selected.size === 0) return;
     if (!confirm(`Approve ${selected.size} comment(s)?`)) return;
+    const ids = Array.from(selected);
     try {
-      await api.post('/admin/comments/bulk-approve', {
-        commentIds: Array.from(selected)
-      });
-      toast.success(`${selected.size} comment(s) approved`);
+      await api.post('/admin/comments/bulk-approve', { commentIds: ids });
+      removeFromList(ids);
       setSelected(new Set());
-      load(1);
+      toast.success(`${ids.length} comment(s) approved`);
     } catch {
       toast.error('Failed to approve comments');
     }
   };
 
   const bulkReject = async () => {
+    if (selected.size === 0) return;
     if (!confirm(`Reject ${selected.size} comment(s)?`)) return;
+    const ids = Array.from(selected);
     try {
-      await api.post('/admin/comments/bulk-reject', {
-        commentIds: Array.from(selected)
-      });
-      toast.success(`${selected.size} comment(s) rejected`);
+      await api.post('/admin/comments/bulk-reject', { commentIds: ids });
+      removeFromList(ids);
       setSelected(new Set());
-      load(1);
+      toast.success(`${ids.length} comment(s) rejected`);
     } catch {
       toast.error('Failed to reject comments');
     }
   };
 
-  const toggle = (id: string) => {
-    setSelected((prev) => {
-      const n = new Set(prev);
-      if (n.has(id)) n.delete(id);
-      else n.add(id);
-      return n;
-    });
+  /**
+   * onClick fires BEFORE the native checkbox flips its checked state, so
+   * `selected.has(id)` here is the pre-click state. We invert it ourselves
+   * and (for shift-click) propagate that target state across the range —
+   * the standard email/file-manager shift-click behaviour.
+   */
+  const onCheckboxClick = (
+    id: string,
+    idx: number,
+    e: React.MouseEvent<HTMLInputElement>
+  ) => {
+    const isCurrentlySelected = selected.has(id);
+    const targetState = !isCurrentlySelected;
+    const next = new Set(selected);
+
+    if (e.shiftKey && anchorIdx !== null && anchorIdx !== idx) {
+      const [lo, hi] = [Math.min(anchorIdx, idx), Math.max(anchorIdx, idx)];
+      for (let i = lo; i <= hi; i++) {
+        const cid = comments[i]?.id;
+        if (!cid) continue;
+        if (targetState) next.add(cid);
+        else next.delete(cid);
+      }
+    } else {
+      if (targetState) next.add(id);
+      else next.delete(id);
+    }
+    setSelected(next);
+    setAnchorIdx(idx);
+  };
+
+  const toggleAll = () => {
+    if (selected.size === comments.length) setSelected(new Set());
+    else setSelected(new Set(comments.map((c) => c.id)));
   };
 
   return (
     <Card>
       <CardTitle>Pending Comments</CardTitle>
+      <p
+        style={{
+          fontSize: '0.75rem',
+          color: '#888',
+          margin: '0 0 0.5rem 0'
+        }}
+      >
+        Unapproved comments are hidden from everyone except their author until
+        you approve them. Tip: click a checkbox, then shift-click another row to
+        (de)select the whole range.
+      </p>
       {selected.size > 0 && (
         <ButtonRow>
           <Button onClick={bulkApprove}>Approve ({selected.size})</Button>
@@ -330,39 +500,139 @@ function CommentsTab() {
       {comments.length === 0 ? (
         <EmptyState>No pending comments.</EmptyState>
       ) : (
-        comments.map((c) => (
-          <InfoRow key={c.id}>
-            <div
-              style={{
-                display: 'flex',
-                gap: '0.5rem',
-                alignItems: 'flex-start',
-                flex: 1
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={selected.has(c.id)}
-                onChange={() => toggle(c.id)}
-              />
-              <div style={{ flex: 1 }}>
-                <InfoValue>{c.user?.username || 'Unknown'}</InfoValue>
-                <Badge $color="#999">on {c.postTitle || c.slug}</Badge>
-                <br />
-                <InfoLabel>
-                  {c.content.substring(0, 150)}
-                  {c.content.length > 150 ? '...' : ''}
-                </InfoLabel>
-              </div>
-            </div>
-            <ButtonRow>
-              <Button onClick={() => approve(c.id)}>Approve</Button>
-              <Button $variant="danger" onClick={() => reject(c.id)}>
-                Reject
-              </Button>
-            </ButtonRow>
-          </InfoRow>
-        ))
+        <PendingTableWrapper>
+          <PendingTable>
+            <thead>
+              <tr>
+                <th style={{ width: 28 }}>
+                  <TableCheckbox
+                    checked={
+                      selected.size > 0 && selected.size === comments.length
+                    }
+                    ref={(el) => {
+                      // Indeterminate state when some-but-not-all selected.
+                      if (el)
+                        el.indeterminate =
+                          selected.size > 0 && selected.size < comments.length;
+                    }}
+                    onChange={toggleAll}
+                  />
+                </th>
+                <th>Author</th>
+                <th>Account</th>
+                <th>History</th>
+                <th>Karma</th>
+                <th>Comment</th>
+                <th>Posted</th>
+                <th style={{ width: 130 }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comments.map((c, idx) => {
+                const flavour = reputationFlavour(c);
+                const isSel = selected.has(c.id);
+                return (
+                  <tr key={c.id} className={isSel ? 'selected' : ''}>
+                    <td>
+                      <TableCheckbox
+                        checked={isSel}
+                        onChange={() => {
+                          /* handled in onClick to capture shiftKey */
+                        }}
+                        onClick={(e) => onCheckboxClick(c.id, idx, e)}
+                      />
+                    </td>
+                    <td>
+                      <a
+                        href={`/profile/${c.user?.username || ''}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {c.user?.username || '(unknown)'}
+                      </a>
+                      <div>
+                        <Badge $color={flavour.colour}>{flavour.label}</Badge>
+                      </div>
+                    </td>
+                    <td>
+                      <div className="meta">
+                        {c.authorAccountAgeDays === 0
+                          ? '<1 day'
+                          : `${c.authorAccountAgeDays} day${c.authorAccountAgeDays === 1 ? '' : 's'}`}
+                      </div>
+                    </td>
+                    <td>
+                      <Sparkline>
+                        <span style={{ color: '#0F9960' }}>
+                          ✓ {c.authorApprovedCount}
+                        </span>{' '}
+                        <span style={{ color: '#c62828' }}>
+                          ✗ {c.authorRejectedCount}
+                        </span>{' '}
+                        <span style={{ color: '#996f0f' }}>
+                          … {c.authorPendingCount}
+                        </span>
+                      </Sparkline>
+                      <div className="meta">{c.authorTotalComments} total</div>
+                    </td>
+                    <td>
+                      <Sparkline>
+                        <span style={{ color: '#0F9960' }}>
+                          ▲ {c.authorTotalLikesReceived}
+                        </span>{' '}
+                        <span style={{ color: '#c62828' }}>
+                          ▼ {c.authorTotalDislikesReceived}
+                        </span>
+                      </Sparkline>
+                      <div className="meta">
+                        net{' '}
+                        {c.authorTotalLikesReceived -
+                          c.authorTotalDislikesReceived}
+                      </div>
+                    </td>
+                    <td>
+                      <div className="content-preview">
+                        {c.content.length > 200
+                          ? c.content.substring(0, 200) + '…'
+                          : c.content}
+                      </div>
+                      <div className="meta">
+                        on{' '}
+                        <a href={`/${c.slug}`} target="_blank" rel="noreferrer">
+                          {c.postTitle || c.slug}
+                        </a>{' '}
+                        · this comment: ▲ {c.commentLikes} ▼ {c.commentDislikes}
+                      </div>
+                    </td>
+                    <td>
+                      <div className="meta">
+                        {new Date(c.createdAt).toLocaleString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                          hour: '2-digit',
+                          minute: '2-digit'
+                        })}
+                      </div>
+                    </td>
+                    <td>
+                      <InlineActions>
+                        <MiniButton onClick={() => approve(c.id)}>
+                          Approve
+                        </MiniButton>
+                        <MiniButton
+                          $variant="reject"
+                          onClick={() => reject(c.id)}
+                        >
+                          Reject
+                        </MiniButton>
+                      </InlineActions>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </PendingTable>
+        </PendingTableWrapper>
       )}
       {hasMore && (
         <ButtonRow>

--- a/client/src/app/admin/page.tsx
+++ b/client/src/app/admin/page.tsx
@@ -25,6 +25,14 @@ import {
   TabBar,
   Tab
 } from '@/components/ui/PageStyles';
+import {
+  DataTable,
+  DataTableWrapper,
+  DataTableCheckbox,
+  SelectAllCheckbox
+} from '@/components/ui/DataTable';
+import { BulkActionBar } from '@/components/ui/BulkActionBar';
+import { useRangeSelect } from '@/components/ui/useRangeSelect';
 import styled from 'styled-components';
 
 const StatGrid = styled.div`
@@ -240,62 +248,9 @@ function OverviewTab() {
 // ── Pending Comments: rich table + shift-click multi-select ────────────────
 //
 // Reputation columns surface the cursory information an admin needs without
-// having to click into the user's profile. Shift-click on a checkbox selects
-// the range from the last clicked row to the current row (toggling all of
-// them to the current row's new state) — the standard table-multiselect
-// keyboard convention.
-
-const PendingTableWrapper = styled.div`
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-`;
-
-const PendingTable = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.8rem;
-  font-family: ${(p) => p.theme.text.font.roboto};
-
-  th,
-  td {
-    padding: 6px 8px;
-    text-align: left;
-    border-bottom: 1px solid ${(p) => p.theme.container.border.colour.primary()};
-    vertical-align: top;
-  }
-
-  th {
-    font-weight: ${(p) => p.theme.text.weight.bold};
-    color: ${(p) => p.theme.text.colour.light_grey()};
-    text-transform: uppercase;
-    font-size: 0.65rem;
-    letter-spacing: 0.05em;
-    border-bottom: 2px solid ${(p) => p.theme.text.colour.header()};
-    white-space: nowrap;
-  }
-
-  tbody tr.selected {
-    background: ${(p) => p.theme.text.colour.header()}10;
-  }
-
-  td .content-preview {
-    max-width: 340px;
-    color: ${(p) => p.theme.text.colour.primary()};
-    line-height: 1.35;
-  }
-
-  td .meta {
-    color: ${(p) => p.theme.text.colour.light_grey()};
-    font-size: 0.7rem;
-  }
-`;
-
-const TableCheckbox = styled.input.attrs({ type: 'checkbox' })`
-  cursor: pointer;
-  /* Big hit area so shift-clicking on a fiddly checkbox isn't a sniper shot. */
-  width: 16px;
-  height: 16px;
-`;
+// having to click into the user's profile. Shift-click range select is
+// provided by the shared useRangeSelect hook so other moderation surfaces
+// (Users tab, future moderator queues) reuse the same behaviour.
 
 const InlineActions = styled.div`
   display: flex;
@@ -355,10 +310,7 @@ function CommentsTab() {
   const [comments, setComments] = useState<AdminPendingComment[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
-  const [selected, setSelected] = useState<Set<string>>(new Set());
-  // Index of the last checkbox-clicked row. Shift-click reads this to compute
-  // the range. Reset on data reloads so we can't anchor to a now-stale row.
-  const [anchorIdx, setAnchorIdx] = useState<number | null>(null);
+  const sel = useRangeSelect(comments);
 
   useEffect(() => {
     load(1);
@@ -372,21 +324,22 @@ function CommentsTab() {
     setComments(p === 1 ? data.data : [...comments, ...data.data]);
     setHasMore(data.hasMore);
     setPage(p);
-    setAnchorIdx(null);
+    sel.resetAnchor();
   };
 
-  const removeFromList = (ids: string[]) =>
+  const removeFromList = (ids: string[]) => {
     setComments((prev) => prev.filter((c) => !ids.includes(c.id)));
+    sel.setSelected((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) next.delete(id);
+      return next;
+    });
+  };
 
   const approve = async (id: string) => {
     try {
       await api.post(`/admin/comments/${id}/approve`);
       removeFromList([id]);
-      setSelected((prev) => {
-        const n = new Set(prev);
-        n.delete(id);
-        return n;
-      });
       toast.success('Comment approved');
     } catch {
       toast.error('Failed to approve');
@@ -397,11 +350,6 @@ function CommentsTab() {
     try {
       await api.post(`/admin/comments/${id}/reject`);
       removeFromList([id]);
-      setSelected((prev) => {
-        const n = new Set(prev);
-        n.delete(id);
-        return n;
-      });
       toast.success('Comment rejected');
     } catch {
       toast.error('Failed to reject');
@@ -409,13 +357,12 @@ function CommentsTab() {
   };
 
   const bulkApprove = async () => {
-    if (selected.size === 0) return;
-    if (!confirm(`Approve ${selected.size} comment(s)?`)) return;
-    const ids = Array.from(selected);
+    if (sel.count === 0) return;
+    if (!confirm(`Approve ${sel.count} comment(s)?`)) return;
+    const ids = Array.from(sel.selected);
     try {
       await api.post('/admin/comments/bulk-approve', { commentIds: ids });
       removeFromList(ids);
-      setSelected(new Set());
       toast.success(`${ids.length} comment(s) approved`);
     } catch {
       toast.error('Failed to approve comments');
@@ -423,53 +370,16 @@ function CommentsTab() {
   };
 
   const bulkReject = async () => {
-    if (selected.size === 0) return;
-    if (!confirm(`Reject ${selected.size} comment(s)?`)) return;
-    const ids = Array.from(selected);
+    if (sel.count === 0) return;
+    if (!confirm(`Reject ${sel.count} comment(s)?`)) return;
+    const ids = Array.from(sel.selected);
     try {
       await api.post('/admin/comments/bulk-reject', { commentIds: ids });
       removeFromList(ids);
-      setSelected(new Set());
       toast.success(`${ids.length} comment(s) rejected`);
     } catch {
       toast.error('Failed to reject comments');
     }
-  };
-
-  /**
-   * onClick fires BEFORE the native checkbox flips its checked state, so
-   * `selected.has(id)` here is the pre-click state. We invert it ourselves
-   * and (for shift-click) propagate that target state across the range —
-   * the standard email/file-manager shift-click behaviour.
-   */
-  const onCheckboxClick = (
-    id: string,
-    idx: number,
-    e: React.MouseEvent<HTMLInputElement>
-  ) => {
-    const isCurrentlySelected = selected.has(id);
-    const targetState = !isCurrentlySelected;
-    const next = new Set(selected);
-
-    if (e.shiftKey && anchorIdx !== null && anchorIdx !== idx) {
-      const [lo, hi] = [Math.min(anchorIdx, idx), Math.max(anchorIdx, idx)];
-      for (let i = lo; i <= hi; i++) {
-        const cid = comments[i]?.id;
-        if (!cid) continue;
-        if (targetState) next.add(cid);
-        else next.delete(cid);
-      }
-    } else {
-      if (targetState) next.add(id);
-      else next.delete(id);
-    }
-    setSelected(next);
-    setAnchorIdx(idx);
-  };
-
-  const toggleAll = () => {
-    if (selected.size === comments.length) setSelected(new Set());
-    else setSelected(new Set(comments.map((c) => c.id)));
   };
 
   return (
@@ -486,36 +396,24 @@ function CommentsTab() {
         you approve them. Tip: click a checkbox, then shift-click another row to
         (de)select the whole range.
       </p>
-      {selected.size > 0 && (
-        <ButtonRow>
-          <Button onClick={bulkApprove}>Approve ({selected.size})</Button>
-          <Button $variant="danger" onClick={bulkReject}>
-            Reject ({selected.size})
-          </Button>
-          <Button $variant="secondary" onClick={() => setSelected(new Set())}>
-            Clear
-          </Button>
-        </ButtonRow>
-      )}
+      <BulkActionBar count={sel.count} onClear={sel.clear}>
+        <Button onClick={bulkApprove}>Approve ({sel.count})</Button>
+        <Button $variant="danger" onClick={bulkReject}>
+          Reject ({sel.count})
+        </Button>
+      </BulkActionBar>
       {comments.length === 0 ? (
         <EmptyState>No pending comments.</EmptyState>
       ) : (
-        <PendingTableWrapper>
-          <PendingTable>
+        <DataTableWrapper>
+          <DataTable>
             <thead>
               <tr>
                 <th style={{ width: 28 }}>
-                  <TableCheckbox
-                    checked={
-                      selected.size > 0 && selected.size === comments.length
-                    }
-                    ref={(el) => {
-                      // Indeterminate state when some-but-not-all selected.
-                      if (el)
-                        el.indeterminate =
-                          selected.size > 0 && selected.size < comments.length;
-                    }}
-                    onChange={toggleAll}
+                  <SelectAllCheckbox
+                    checked={sel.isAllSelected}
+                    indeterminate={sel.isIndeterminate}
+                    onChange={sel.toggleAll}
                   />
                 </th>
                 <th>Author</th>
@@ -530,16 +428,16 @@ function CommentsTab() {
             <tbody>
               {comments.map((c, idx) => {
                 const flavour = reputationFlavour(c);
-                const isSel = selected.has(c.id);
+                const isSel = sel.isSelected(c.id);
                 return (
                   <tr key={c.id} className={isSel ? 'selected' : ''}>
                     <td>
-                      <TableCheckbox
+                      <DataTableCheckbox
                         checked={isSel}
                         onChange={() => {
                           /* handled in onClick to capture shiftKey */
                         }}
-                        onClick={(e) => onCheckboxClick(c.id, idx, e)}
+                        onClick={(e) => sel.onCheckboxClick(c.id, idx, e)}
                       />
                     </td>
                     <td>
@@ -631,8 +529,8 @@ function CommentsTab() {
                 );
               })}
             </tbody>
-          </PendingTable>
-        </PendingTableWrapper>
+          </DataTable>
+        </DataTableWrapper>
       )}
       {hasMore && (
         <ButtonRow>
@@ -653,8 +551,18 @@ function UsersTab() {
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
-  const [selected, setSelected] = useState<Set<string>>(new Set());
   const [filterGroup, setFilterGroup] = useState<string>('all');
+
+  const filteredUsers =
+    filterGroup === 'all'
+      ? users
+      : filterGroup === 'banned'
+        ? users.filter((u) => u.isBanned)
+        : users.filter((u) => u.groups.includes(filterGroup));
+
+  // Bind selection to the visible (filtered) list — the standard mental model
+  // for "select all" when a filter is applied.
+  const sel = useRangeSelect(filteredUsers);
 
   useEffect(() => {
     load(1);
@@ -667,6 +575,7 @@ function UsersTab() {
     setUsers(p === 1 ? data.data : [...users, ...data.data]);
     setHasMore(data.hasMore);
     setPage(p);
+    sel.resetAnchor();
   };
 
   const ban = async (id: string) => {
@@ -680,30 +589,14 @@ function UsersTab() {
     load(1);
   };
 
-  const toggle = (id: string) => {
-    setSelected((prev) => {
-      const n = new Set(prev);
-      if (n.has(id)) n.delete(id);
-      else n.add(id);
-      return n;
-    });
-  };
-
   const bulkBan = async () => {
-    if (!confirm(`Ban ${selected.size} user(s)?`)) return;
+    if (!confirm(`Ban ${sel.count} user(s)?`)) return;
     const reason = prompt('Ban reason (optional):');
-    for (const id of selected)
+    for (const id of sel.selected)
       await api.post(`/admin/users/${id}/ban`, { reason });
-    setSelected(new Set());
+    sel.clear();
     load(1);
   };
-
-  const filteredUsers =
-    filterGroup === 'all'
-      ? users
-      : filterGroup === 'banned'
-        ? users.filter((u) => u.isBanned)
-        : users.filter((u) => u.groups.includes(filterGroup));
 
   const groupCounts = {
     all: users.length,
@@ -748,17 +641,12 @@ function UsersTab() {
           </button>
         ))}
       </div>
-      {selected.size > 0 && (
-        <ButtonRow>
-          <Button $variant="danger" onClick={bulkBan}>
-            Ban Selected ({selected.size})
-          </Button>
-          <Button $variant="secondary" onClick={() => setSelected(new Set())}>
-            Clear
-          </Button>
-        </ButtonRow>
-      )}
-      {filteredUsers.map((u) => (
+      <BulkActionBar count={sel.count} onClear={sel.clear}>
+        <Button $variant="danger" onClick={bulkBan}>
+          Ban Selected ({sel.count})
+        </Button>
+      </BulkActionBar>
+      {filteredUsers.map((u, idx) => (
         <InfoRow key={u.id}>
           <div
             style={{
@@ -768,10 +656,12 @@ function UsersTab() {
               flex: 1
             }}
           >
-            <input
-              type="checkbox"
-              checked={selected.has(u.id)}
-              onChange={() => toggle(u.id)}
+            <DataTableCheckbox
+              checked={sel.isSelected(u.id)}
+              onChange={() => {
+                /* handled in onClick to capture shiftKey */
+              }}
+              onClick={(e) => sel.onCheckboxClick(u.id, idx, e)}
             />
             <div>
               <InfoValue>

--- a/client/src/app/dictionaries/biology/[slug]/page.tsx
+++ b/client/src/app/dictionaries/biology/[slug]/page.tsx
@@ -31,7 +31,7 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
     return { slug };
   });
 
-  return config.isProduction ? slugs : slugs.slice(0, 3);
+  return slugs;
 }
 
 async function Page({ params }: { params: Promise<{ slug: string }> }) {

--- a/client/src/app/dictionaries/chemistry/[slug]/page.tsx
+++ b/client/src/app/dictionaries/chemistry/[slug]/page.tsx
@@ -31,7 +31,7 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
     return { slug };
   });
 
-  return config.isProduction ? slugs : slugs.slice(0, 3);
+  return slugs;
 }
 
 async function Page({ params }: { params: Promise<{ slug: string }> }) {

--- a/client/src/app/dictionaries/generateStaticParams.test.ts
+++ b/client/src/app/dictionaries/generateStaticParams.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+
+// Regression guard for the Bun + Next.js on-demand RSC MDX compile crash
+// (Object.keys of undefined inside @mdx-js/mdx recma-jsx-rewrite). On-demand
+// rendering is unusable, so every dictionary [slug] page MUST pre-build every
+// MDX file via generateStaticParams. A future "let me speed up dev builds by
+// slicing" change would silently 500 on dev again — this test makes that
+// regression loud and synchronous.
+
+const DICTIONARIES = ['biology', 'chemistry', 'mathematics'] as const;
+
+const APP_DIR = path.resolve(import.meta.dir, '..');
+const PAGE_PATH = (dict: string) =>
+  path.join(APP_DIR, 'dictionaries', dict, '[slug]', 'page.tsx');
+const DEFINITIONS_DIR = (dict: string) =>
+  path.join(APP_DIR, 'dictionaries', dict, 'definitions');
+
+const GENERATE_STATIC_PARAMS_BLOCK =
+  /export\s+async\s+function\s+generateStaticParams[\s\S]*?\n\}/m;
+
+describe('dictionary generateStaticParams', () => {
+  for (const dict of DICTIONARIES) {
+    describe(dict, () => {
+      const source = fs.readFileSync(PAGE_PATH(dict), 'utf-8');
+      const match = source.match(GENERATE_STATIC_PARAMS_BLOCK);
+
+      test('generateStaticParams is exported', () => {
+        expect(match).not.toBeNull();
+      });
+
+      test('does NOT slice/limit the slug list', () => {
+        // .slice( inside generateStaticParams would re-introduce the dev SSG
+        // split that left non-prebuilt slugs to the broken on-demand path.
+        expect(match![0]).not.toMatch(/\.slice\s*\(/);
+      });
+
+      test('does NOT branch on isProduction', () => {
+        // The original regression used `config.isProduction ? slugs : slugs.slice(0,3)`.
+        // Any env-conditional return is suspicious here.
+        expect(match![0]).not.toMatch(/isProduction/);
+      });
+
+      test('returns every .mdx file in the definitions dir (file count > 3)', () => {
+        const files = fs
+          .readdirSync(DEFINITIONS_DIR(dict))
+          .filter((f) => f.endsWith('.mdx'));
+        // Original bug pre-built only first 3. If a future change accidentally
+        // pre-builds only a handful, the count alone won't catch it (no easy
+        // hook into the function), but we can at least assert there ARE more
+        // than 3 .mdx files — so any "slice(0,3)" reintroduction would
+        // mismatch reality.
+        expect(files.length).toBeGreaterThan(3);
+      });
+    });
+  }
+});

--- a/client/src/app/dictionaries/mathematics/[slug]/page.tsx
+++ b/client/src/app/dictionaries/mathematics/[slug]/page.tsx
@@ -31,7 +31,7 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
     return { slug };
   });
 
-  return config.isProduction ? slugs : slugs.slice(0, 3);
+  return slugs;
 }
 
 async function Page({ params }: { params: Promise<{ slug: string }> }) {

--- a/client/src/components/comments/CommentItem.tsx
+++ b/client/src/components/comments/CommentItem.tsx
@@ -207,7 +207,9 @@ export function CommentItem({
                 </EditedBadge>
               )}
               {!comment.approved && (
-                <PendingBadge>pending approval</PendingBadge>
+                <PendingBadge title="Only you can see this comment until a moderator approves it. New accounts are queued by default; trusted users post directly.">
+                  pending review — only visible to you
+                </PendingBadge>
               )}
             </>
           )}

--- a/client/src/components/graph/KnowledgeGraphCanvas.tsx
+++ b/client/src/components/graph/KnowledgeGraphCanvas.tsx
@@ -14,10 +14,10 @@ import { GraphSimulation, GraphRenderer } from '@/lib/graph';
 import type { SimNode, SimEdge } from '@/lib/graph';
 import type { SearchMode } from '@/lib/graph/GraphRenderer';
 
-import { ENV_CONFIG, type BuildEnv } from '@derecksnotes/shared';
+import { ENV_CONFIG, type AppEnv } from '@derecksnotes/shared';
 
-const BUILD_ENV = (process.env.BUILD_ENV as BuildEnv) || 'local';
-const API_URL = ENV_CONFIG[BUILD_ENV].apiUrl;
+const APP_ENV = (process.env.NEXT_PUBLIC_APP_ENV as AppEnv) || 'local';
+const API_URL = ENV_CONFIG[APP_ENV].apiUrl;
 
 // ── default query options ────────────────────────────────────────────
 export const DEFAULT_GRAPH_OPTIONS: GraphQueryOptions = {

--- a/client/src/components/ui/BulkActionBar.tsx
+++ b/client/src/components/ui/BulkActionBar.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React from 'react';
+import { Button, ButtonRow } from './PageStyles';
+
+/**
+ * Toolbar that surfaces above a selectable list/table when one or more
+ * rows are selected. Composes with useRangeSelect — pass the count and
+ * onClear from the hook, render whatever action buttons the host needs
+ * as children.
+ *
+ * Returns null when count === 0 so hosts can keep this in the render
+ * tree unconditionally without managing visibility themselves.
+ *
+ * Usage:
+ *   const sel = useRangeSelect(rows);
+ *   <BulkActionBar count={sel.count} onClear={sel.clear}>
+ *     <Button onClick={() => approveMany(Array.from(sel.selected))}>
+ *       Approve ({sel.count})
+ *     </Button>
+ *     <Button $variant="danger" onClick={() => rejectMany(Array.from(sel.selected))}>
+ *       Reject ({sel.count})
+ *     </Button>
+ *   </BulkActionBar>
+ */
+export interface BulkActionBarProps {
+  count: number;
+  onClear: () => void;
+  children: React.ReactNode;
+  clearLabel?: string;
+}
+
+export function BulkActionBar({
+  count,
+  onClear,
+  children,
+  clearLabel = 'Clear'
+}: BulkActionBarProps) {
+  if (count === 0) return null;
+  return (
+    <ButtonRow>
+      {children}
+      <Button $variant="secondary" onClick={onClear}>
+        {clearLabel}
+      </Button>
+    </ButtonRow>
+  );
+}

--- a/client/src/components/ui/DataTable.tsx
+++ b/client/src/components/ui/DataTable.tsx
@@ -1,0 +1,93 @@
+'use client';
+import React, { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+
+/**
+ * Generic data-table primitives. The site's prior pattern was inline
+ * `<table>` markup with bespoke styling per page; this file is the canonical
+ * styled-table for the codebase. Pair with useRangeSelect for shift-click
+ * multi-select.
+ *
+ * The components here are styled HTML — they intentionally do NOT take
+ * data props. Hosts compose them: <DataTable><thead><DataTableHeaderRow>...
+ * Use the same conventions site-wide so visual rhythm stays consistent.
+ */
+
+export const DataTableWrapper = styled.div`
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+`;
+
+export const DataTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  font-family: ${(p) => p.theme.text.font.roboto};
+
+  th,
+  td {
+    padding: 6px 8px;
+    text-align: left;
+    border-bottom: 1px solid ${(p) => p.theme.container.border.colour.primary()};
+    vertical-align: top;
+  }
+
+  th {
+    font-weight: ${(p) => p.theme.text.weight.bold};
+    color: ${(p) => p.theme.text.colour.light_grey()};
+    text-transform: uppercase;
+    font-size: 0.65rem;
+    letter-spacing: 0.05em;
+    border-bottom: 2px solid ${(p) => p.theme.text.colour.header()};
+    white-space: nowrap;
+  }
+
+  tbody tr.selected {
+    background: ${(p) => p.theme.text.colour.header()}10;
+  }
+
+  td .content-preview {
+    max-width: 340px;
+    color: ${(p) => p.theme.text.colour.primary()};
+    line-height: 1.35;
+  }
+
+  td .meta {
+    color: ${(p) => p.theme.text.colour.light_grey()};
+    font-size: 0.7rem;
+  }
+`;
+
+export const DataTableCheckbox = styled.input.attrs({ type: 'checkbox' })`
+  cursor: pointer;
+  /* Bigger hit area so shift-clicking a fiddly checkbox isn't a sniper shot. */
+  width: 16px;
+  height: 16px;
+`;
+
+/**
+ * Header checkbox that drives an indeterminate state when only some rows
+ * are selected — the standard "partial selection" affordance for tables.
+ * `indeterminate` is not a real HTML attribute on the input element; it
+ * has to be assigned on the DOM node, so this component wraps the ref
+ * logic in a hook so consumers don't have to.
+ */
+export interface SelectAllCheckboxProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'type'
+> {
+  checked: boolean;
+  indeterminate: boolean;
+}
+
+export function SelectAllCheckbox({
+  checked,
+  indeterminate,
+  ...rest
+}: SelectAllCheckboxProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return <DataTableCheckbox ref={ref} checked={checked} {...rest} />;
+}

--- a/client/src/components/ui/Footer.tsx
+++ b/client/src/components/ui/Footer.tsx
@@ -49,7 +49,7 @@ function Footer(): ReactElement {
       </FooterText>
       <FooterText>
         v{config.version} ({config.commitSha.slice(0, 7)}) &bull;{' '}
-        {config.buildEnv}
+        {config.appEnv}
       </FooterText>
       <FooterText>
         <a href="mailto:contact@derecksnotes.com">contact@derecksnotes.com</a>

--- a/client/src/components/ui/useRangeSelect.test.ts
+++ b/client/src/components/ui/useRangeSelect.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { useRangeSelect } from './useRangeSelect';
+
+// Minimal mock of React.MouseEvent — only the fields the hook reads.
+function clickEvent(shiftKey: boolean) {
+  return { shiftKey } as unknown as React.MouseEvent<HTMLInputElement>;
+}
+
+const ITEMS = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }];
+
+describe('useRangeSelect', () => {
+  test('single click toggles the row', () => {
+    const { result } = renderHook(() => useRangeSelect(ITEMS));
+    act(() => result.current.onCheckboxClick('b', 1, clickEvent(false)));
+    expect(result.current.isSelected('b')).toBe(true);
+    expect(result.current.count).toBe(1);
+
+    act(() => result.current.onCheckboxClick('b', 1, clickEvent(false)));
+    expect(result.current.isSelected('b')).toBe(false);
+    expect(result.current.count).toBe(0);
+  });
+
+  test('shift-click selects the range to target state', () => {
+    const { result } = renderHook(() => useRangeSelect(ITEMS));
+    // anchor on b (idx 1)
+    act(() => result.current.onCheckboxClick('b', 1, clickEvent(false)));
+    // shift-click on e (idx 4) — b..e should now be selected
+    act(() => result.current.onCheckboxClick('e', 4, clickEvent(true)));
+    expect(Array.from(result.current.selected).sort()).toEqual([
+      'b',
+      'c',
+      'd',
+      'e'
+    ]);
+  });
+
+  test('shift-click deselects when target was already selected', () => {
+    const { result } = renderHook(() => useRangeSelect(ITEMS));
+    act(() => result.current.selectAll());
+    expect(result.current.count).toBe(5);
+    // anchor on b
+    act(() => result.current.onCheckboxClick('b', 1, clickEvent(false)));
+    // b is now deselected; shift-click on d — b..d all match the new target
+    // (deselect), so c+d also drop. a stays selected, e stays selected.
+    act(() => result.current.onCheckboxClick('d', 3, clickEvent(true)));
+    expect(Array.from(result.current.selected).sort()).toEqual(['a', 'e']);
+  });
+
+  test('clear removes all selection and the anchor', () => {
+    const { result } = renderHook(() => useRangeSelect(ITEMS));
+    act(() => result.current.selectAll());
+    expect(result.current.count).toBe(5);
+    act(() => result.current.clear());
+    expect(result.current.count).toBe(0);
+
+    // After clear, the next click acts as a new anchor (no implicit range).
+    act(() => result.current.onCheckboxClick('c', 2, clickEvent(false)));
+    act(() => result.current.onCheckboxClick('e', 4, clickEvent(true)));
+    expect(Array.from(result.current.selected).sort()).toEqual(['c', 'd', 'e']);
+  });
+
+  test('isIndeterminate is true only for partial selection', () => {
+    const { result } = renderHook(() => useRangeSelect(ITEMS));
+    expect(result.current.isIndeterminate).toBe(false);
+    expect(result.current.isAllSelected).toBe(false);
+
+    act(() => result.current.toggle('a'));
+    expect(result.current.isIndeterminate).toBe(true);
+    expect(result.current.isAllSelected).toBe(false);
+
+    act(() => result.current.selectAll());
+    expect(result.current.isIndeterminate).toBe(false);
+    expect(result.current.isAllSelected).toBe(true);
+  });
+
+  test('toggleAll flips between empty and full', () => {
+    const { result } = renderHook(() => useRangeSelect(ITEMS));
+    act(() => result.current.toggleAll());
+    expect(result.current.count).toBe(5);
+    act(() => result.current.toggleAll());
+    expect(result.current.count).toBe(0);
+  });
+
+  test('shift-click without a prior anchor falls back to single toggle', () => {
+    const { result } = renderHook(() => useRangeSelect(ITEMS));
+    act(() => result.current.onCheckboxClick('c', 2, clickEvent(true)));
+    expect(Array.from(result.current.selected)).toEqual(['c']);
+  });
+});

--- a/client/src/components/ui/useRangeSelect.ts
+++ b/client/src/components/ui/useRangeSelect.ts
@@ -1,0 +1,126 @@
+'use client';
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+/**
+ * Multi-select hook with email/file-manager-style shift-click range
+ * selection. Designed to be table-agnostic — pass the visible items
+ * (in their on-screen order), get back the selection state and a
+ * checkbox onClick handler that already understands shift-click.
+ *
+ * Why a hook and not a wrapped <SelectableList>:
+ * - Hosts retain control over markup (table, list, grid).
+ * - Selection state is exposed for hosts that want to drive bulk
+ *   actions from outside the list (toolbars, keyboard shortcuts).
+ *
+ * Usage:
+ *   const sel = useRangeSelect(rows);
+ *   <input
+ *     type="checkbox"
+ *     checked={sel.isSelected(row.id)}
+ *     onChange={() => {}}            // suppress React warning
+ *     onClick={(e) => sel.onCheckboxClick(row.id, idx, e)}
+ *   />
+ *   sel.selected      // Set<string>
+ *   sel.clear()
+ *   sel.selectAll()
+ *   sel.isIndeterminate
+ *   sel.isAllSelected
+ *   sel.resetAnchor() // call after re-fetching the underlying data
+ */
+export function useRangeSelect<T extends { id: string }>(items: T[]) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const anchorRef = useRef<number | null>(null);
+
+  const isSelected = useCallback((id: string) => selected.has(id), [selected]);
+
+  const clear = useCallback(() => {
+    setSelected(new Set());
+    anchorRef.current = null;
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelected(new Set(items.map((i) => i.id)));
+  }, [items]);
+
+  const toggleAll = useCallback(() => {
+    setSelected((prev) => {
+      if (prev.size === items.length && items.length > 0) {
+        anchorRef.current = null;
+        return new Set();
+      }
+      return new Set(items.map((i) => i.id));
+    });
+  }, [items]);
+
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const resetAnchor = useCallback(() => {
+    anchorRef.current = null;
+  }, []);
+
+  /**
+   * onClick fires BEFORE the native checkbox toggles its checked state, so
+   * `selected.has(id)` here reflects the pre-click state. We invert it
+   * ourselves and (for shift-click) propagate that target state across
+   * the range — standard shift-click semantics.
+   *
+   * IMPORTANT: pair this with `onChange={() => {}}` on the checkbox so
+   * React doesn't warn about the controlled input. We need controlled to
+   * keep `checked` in sync with `selected`.
+   */
+  const onCheckboxClick = useCallback(
+    (id: string, idx: number, e: React.MouseEvent<HTMLInputElement>) => {
+      const isCurrentlySelected = selected.has(id);
+      const targetState = !isCurrentlySelected;
+      const next = new Set(selected);
+      const anchor = anchorRef.current;
+
+      if (e.shiftKey && anchor !== null && anchor !== idx) {
+        const [lo, hi] = [Math.min(anchor, idx), Math.max(anchor, idx)];
+        for (let i = lo; i <= hi; i++) {
+          const rowId = items[i]?.id;
+          if (!rowId) continue;
+          if (targetState) next.add(rowId);
+          else next.delete(rowId);
+        }
+      } else {
+        if (targetState) next.add(id);
+        else next.delete(id);
+      }
+      setSelected(next);
+      anchorRef.current = idx;
+    },
+    [items, selected]
+  );
+
+  const isAllSelected = useMemo(
+    () => items.length > 0 && selected.size === items.length,
+    [items.length, selected.size]
+  );
+  const isIndeterminate = useMemo(
+    () => selected.size > 0 && selected.size < items.length,
+    [items.length, selected.size]
+  );
+
+  return {
+    selected,
+    setSelected,
+    isSelected,
+    toggle,
+    clear,
+    selectAll,
+    toggleAll,
+    resetAnchor,
+    onCheckboxClick,
+    isAllSelected,
+    isIndeterminate,
+    count: selected.size
+  };
+}

--- a/client/src/lib/env.ts
+++ b/client/src/lib/env.ts
@@ -1,14 +1,14 @@
 import pkg from '../../../package.json';
-import { ENV_CONFIG, type BuildEnv } from '@derecksnotes/shared';
+import { ENV_CONFIG, type AppEnv } from '@derecksnotes/shared';
 
-const BUILD_ENV = (process.env.BUILD_ENV as BuildEnv) || 'local';
+const APP_ENV = (process.env.NEXT_PUBLIC_APP_ENV as AppEnv) || 'local';
 
-const derived = ENV_CONFIG[BUILD_ENV];
+const derived = ENV_CONFIG[APP_ENV];
 
 export const config = {
   version: pkg.version,
-  buildEnv: BUILD_ENV,
-  isProduction: BUILD_ENV === 'prod',
+  appEnv: APP_ENV,
+  isProduction: APP_ENV === 'prod',
   commitSha: process.env.NEXT_PUBLIC_COMMIT_SHA || 'local',
   domain: derived.domain,
   baseUrl: derived.baseUrl,

--- a/client/src/utils/mdx/processMdx.ts
+++ b/client/src/utils/mdx/processMdx.ts
@@ -42,10 +42,6 @@ export async function processMdx<
         parseFrontmatter: true,
         // REF: https://github.com/hashicorp/next-mdx-remote/issues/356#issuecomment-1556074660
         mdxOptions: {
-          // Pin to the production jsx runtime explicitly. Belt and braces
-          // against NODE_ENV being ambiguous at module-load time under Bun,
-          // which is the root cause of the on-demand MDX 500 we hit on dev.
-          development: false,
           remarkPlugins: [
             remarkGfm,
             remarkUnwrapImages,
@@ -88,6 +84,11 @@ export async function processMdx<
       source: content
     };
   } catch (err) {
+    const e = err as any;
+    console.error('[processMdx] FULL ERROR:', e);
+    console.error('[processMdx] stack:', e?.stack);
+    console.error('[processMdx] cause:', e?.cause);
+    console.error('[processMdx] markdown preview:', markdown.slice(0, 200));
     throw new Error(
       `MDX compilation error: ${err instanceof Error ? err.message : String(err)}\nError occurred when processing: ${markdown}`
     );

--- a/client/src/utils/mdx/processMdx.ts
+++ b/client/src/utils/mdx/processMdx.ts
@@ -42,6 +42,10 @@ export async function processMdx<
         parseFrontmatter: true,
         // REF: https://github.com/hashicorp/next-mdx-remote/issues/356#issuecomment-1556074660
         mdxOptions: {
+          // Pin to the production jsx runtime explicitly. Belt and braces
+          // against NODE_ENV being ambiguous at module-load time under Bun,
+          // which is the root cause of the on-demand MDX 500 we hit on dev.
+          development: false,
           remarkPlugins: [
             remarkGfm,
             remarkUnwrapImages,

--- a/client/src/utils/remark-rehype/rehypeAddHeadingLinks.ts
+++ b/client/src/utils/remark-rehype/rehypeAddHeadingLinks.ts
@@ -15,10 +15,12 @@ export default function rehypeAddHeadingLinks() {
         node.type === 'element' &&
         ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes((node as any).tagName)
       ) {
-        const id = (node as any).properties.id;
+        const id = (node as any).properties?.id;
 
-        // if the id is table-of-contents then skip this one
-        if (id === 'table-of-contents') return;
+        // Skip headings that have no id (rehype-slug didn't run on them,
+        // or they arrived as mdxJsxFlowElement with attributes instead of
+        // properties). Also skip the Table of contents heading itself.
+        if (!id || id === 'table-of-contents') return;
 
         // Create link element
         const link = {
@@ -56,8 +58,8 @@ export default function rehypeAddHeadingLinks() {
         (node as any).children.push(link);
       }
 
-      if ('children' in node) {
-        (node.children as Node[]).forEach(addHeadingLinks);
+      if ('children' in node && Array.isArray((node as any).children)) {
+        ((node as any).children as Node[]).forEach(addHeadingLinks);
       }
     };
 

--- a/client/src/utils/remark-rehype/rehypeTocCollapse.ts
+++ b/client/src/utils/remark-rehype/rehypeTocCollapse.ts
@@ -14,12 +14,16 @@ const rehypeTocCollapse: Plugin = () => {
           if (
             !parent ||
             !Array.isArray(parent.children) ||
-            index === parent.children.length - 1
+            index + 2 >= parent.children.length
           )
             return;
           const subsequentNode = parent.children[index + 2];
 
-          if (subsequentNode.tagName === 'ul') {
+          if (
+            subsequentNode &&
+            subsequentNode.type === 'element' &&
+            subsequentNode.tagName === 'ul'
+          ) {
             // Remove the original h1 (Table of Contents title)
             parent.children.splice(index, 1);
 

--- a/client/test/happy-dom.ts
+++ b/client/test/happy-dom.ts
@@ -1,0 +1,6 @@
+// Bun test preload — sets up happy-dom on the global object so
+// @testing-library/react can call document.body etc. Loaded via
+// bunfig.toml.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+GlobalRegistrator.register();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       args:
-        BUILD_ENV: ${BUILD_ENV:-prod}
+        APP_ENV: ${APP_ENV:-prod}
         COMMIT_SHA: ${COMMIT_SHA:-local}
     image: ${IMAGE_NAME:-derecksnotes}
     container_name: ${CONTAINER_NAME:-derecksnotes}
@@ -11,7 +11,7 @@ services:
       - '${PORT_CLIENT:-3000}:3000'
       - '${PORT_SERVER:-3001}:3001'
     environment:
-      - BUILD_ENV=${BUILD_ENV:-prod}
+      - APP_ENV=${APP_ENV:-prod}
       - SESSION_SECRET=${SESSION_SECRET}
     networks:
       - dereck-network

--- a/docs/spikes/2026-06-18-security-fix-research.md
+++ b/docs/spikes/2026-06-18-security-fix-research.md
@@ -1,0 +1,504 @@
+# Security fix research spike — PR #50
+
+## TL;DR
+- **Session token storage (I3):** Align. Hash at rest with SHA-256 (not bcrypt/Argon2 — tokens already have 256 bits of entropy). Optional HMAC pepper only if you commit to boot-time validation. Single-deployment migration: wipe sessions, force re-login.
+- **Account enumeration (I2):** Refine. Split by surface — accept username-conflict 409 (usernames are public on `/users`), hide email-conflict via the Mozilla send-on-conflict pattern, always-202 on `/forgot-password`, precomputed dummy-bcrypt round on `/login` matching production cost exactly.
+- **Rate limits (I11):** Align with refinements. Dual-key (IP + identifier) per NIST §3.2.2. Add a persistent per-account fail counter — middleware alone does not satisfy NIST. SSE uses a connection-counting Map, not `express-rate-limit`. Boot-time assertion on `trust proxy`.
+- **CSRF (I1):** Refine. Skip synchroniser tokens (no HTML forms). Use stateless `Sec-Fetch-Site` + Origin/Referer allowlist middleware, `__Host-` cookie prefix, audit GETs for side effects. Reject `Sec-Fetch-Site: none` on mutating routes (Rails 8.2 default).
+- **Password policy (I22):** Refine. NIST 800-63B-4 final (Aug 2025) specifies **NFC**, not NFKC — the audit wording is correct. Min 15 / max 128 chars. Migrate to Argon2id via `Bun.password` (no 72-byte cap, no shucking). HIBP k-anonymity check on register/change only.
+- **SSE (B4):** Align with refinements. Explicit `import { randomUUID } from 'node:crypto'`, run through `authenticate()`, in-process Map for connection caps (3/user, 10/IP), heartbeat comment every ~25s, no tokens in URLs (long-lived) — short-lived ≤120s handshake tokens are the documented carve-out if cross-origin ever needed.
+- **Backups (I8/I9/I10):** Align. Litestream v0.5.x → Backblaze B2 fronted by Cloudflare (free egress), `backup-db.yml` invokes `scripts/backup-db.sh` (de-dup), `PRAGMA integrity_check` + `PRAGMA foreign_key_check` on every snapshot, monthly CI restore drill, age envelope encryption, GFS retention.
+- **Transactions (I13/I14/I36):** Refine. Wrapping in `db.transaction()` alone does **not** fix the race — Drizzle defaults to `deferred`. Pass `{ behavior: 'immediate' }` explicitly, set `busy_timeout=5000` at connection open, prefer single-statement UPSERT/`DELETE … NOT IN` patterns. Add `SQLITE_BUSY` retry wrapper.
+
+---
+
+## 1. Session token storage at rest (audit I3)
+
+### Current best practice
+Opaque server-side session tokens generated from `crypto.randomBytes(32)` carry 256 bits of entropy — they cannot be brute-forced. Industry consensus (Lucia v3, Symfony #27910 remember-me fix, GitHub PATs) stores only a fast cryptographic digest (SHA-256) of the token in the database. bcrypt/Argon2 are explicitly inappropriate here: their ~100 ms KDF cost would run on every authenticated request for zero added security against a 2^256 search space. OWASP's Session Management Cheat Sheet documents salted-hash storage for *log* contexts and a 64-bit entropy floor; the "hash at rest" pattern itself is precedented by Lucia and Symfony rather than mandated by OWASP directly.
+
+### Recommended implementation
+Stick with the single-token design (do not adopt Lucia's `<id>.<secret>` split — overkill for a solo-maintainer Express 5 + Drizzle + better-sqlite3 app). Keep the 32-byte token, hash with SHA-256, store hex (64 chars, identical column width to current). Lookup is `SELECT * FROM sessions WHERE tokenHash = ?` — timing-safe for free because the SHA-256 of attacker input randomises the lookup key. Index it: `CREATE UNIQUE INDEX sessions_token_hash_idx ON sessions(token_hash)`.
+
+```ts
+// auth/session.ts
+import { randomBytes, createHash, createHmac } from 'node:crypto';
+
+const PEPPER = process.env.SESSION_TOKEN_PEPPER; // optional; validate at boot
+if (process.env.NODE_ENV === 'production' && !PEPPER) {
+  throw new Error('SESSION_TOKEN_PEPPER required in production');
+}
+
+export function createSessionToken(): { token: string; hash: string } {
+  const token = randomBytes(32).toString('hex');
+  const hash = PEPPER
+    ? createHmac('sha256', PEPPER).update(token).digest('hex')
+    : createHash('sha256').update(token).digest('hex');
+  return { token, hash };
+}
+
+export function hashSessionToken(token: string): string {
+  return PEPPER
+    ? createHmac('sha256', PEPPER).update(token).digest('hex')
+    : createHash('sha256').update(token).digest('hex');
+}
+```
+
+Migration: drop `sessions.token`, add `sessions.tokenHash`, wipe table, ship. Users re-login once — zero risk, no dual-column transition. Centralise in `createSession()` and grep for any other `db.insert(sessions)` callsites before merging. Redact `cookie` headers in `morgan`/`pino-http`.
+
+### Citations
+- https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+- https://lucia-auth.com/sessions/basic
+- https://github.com/symfony/symfony/issues/27910
+- https://nodejs.org/api/crypto.html#cryptorandombytessize-callback
+
+### Codebase-specific notes
+- Bun's `node:crypto` shim supports `randomBytes` and `createHmac` identically — no async `crypto.subtle` needed; keep synchronous code in middleware.
+- Use a single shared `better-sqlite3` connection (the canonical pattern); set `journal_mode=WAL` once at boot.
+- Pepper rotation = global logout. Acceptable operational cost. Do not attempt multi-pepper support.
+- Only add the HMAC pepper if you commit to boot-time env validation; at 256-bit entropy it buys near-zero real security and adds operational surface.
+
+---
+
+## 2. Account enumeration defences (audit I2)
+
+### Current best practice
+OWASP Top 10 2025 A07 and the Authentication Cheat Sheet require identical messages, status codes, and timing across registration, login, and forgot-password. The Forgot Password Cheat Sheet specifies "uniform time" and "consistent message." On login, the canonical fix for the timing oracle is a precomputed dummy bcrypt hash run when the user record is missing (Django #20760, propelauth). On registration, the modern dominant pattern (Mozilla, Stripe, Auth0 community) is always-202 with a generic body plus a context-appropriate out-of-band email. Note: neither cheat sheet formally exempts apps with public username pages — but the *informational* value of hiding usernames is zero when `/users` already enumerates them.
+
+### Recommended implementation
+**Asymmetric by surface, with the threat-model documented in code:**
+
+1. `POST /register` — username conflict returns a specific 409 (usernames are public on `/users`; document this decision). Email conflict returns 202 with the same generic body as the success path, and the welcome-or-conflict email is dispatched via the same queue. **No header asymmetry** (no `Set-Cookie` differences, no `Content-Length` delta).
+2. `POST /login` — precompute `DUMMY_BCRYPT_HASH` at module load using the same library and cost env var as production. Always run `bcrypt.compare` AFTER the SELECT regardless of result. Wrap in try/catch returning identical 401. Both failure branches: byte-identical response.
+3. `POST /forgot-password` — always 202 with fixed body. Enqueue lookup + send in a background job so HTTP timing is decoupled from DB state. Per-IP and per-target-email rate limits to prevent harassment via mass-trigger.
+
+```ts
+// auth/login.ts
+import bcrypt from 'bcrypt';
+const COST = Number(process.env.BCRYPT_COST ?? 12);
+const DUMMY_HASH = await bcrypt.hash('dummy-password', COST); // at module load
+
+export async function login(req, res) {
+  try {
+    const { username, password } = req.body;
+    const user = await db.query.users.findFirst({
+      where: eq(users.username, username.toLowerCase().trim()),
+    });
+    const hash = user?.passwordHash ?? DUMMY_HASH;
+    const ok = await bcrypt.compare(password, hash);
+    if (!ok || !user) return res.status(401).json({ error: 'invalid_credentials' });
+    // success path
+  } catch {
+    return res.status(401).json({ error: 'invalid_credentials' });
+  }
+}
+```
+
+Add an autocannon integration test asserting p95 timing delta `< 5 ms` between known-bad-password and unknown-user. If it fails, the dummy hash is misconfigured (wrong library, wrong cost).
+
+### Citations
+- https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html
+- https://owasp.org/Top10/2025/A07_2025-Authentication_Failures/
+- https://code.djangoproject.com/ticket/20760
+- https://stytch.com/blog/prevent-enumeration-attacks/
+
+### Codebase-specific notes
+- Bun ships bcrypt via napi `node-bcrypt`. Do not mix with `bcryptjs` — different timing profile creates a fresh oracle.
+- Express 5: an unhandled async rejection bubbles to a 500, which itself is an enumeration signal. Wrap auth branches in try/catch returning a uniform 401.
+- Drizzle + SQLite-WAL: a SELECT-miss is microseconds; bcrypt is ~300 ms. The dummy compare MUST run unconditionally after SELECT.
+- If `BCRYPT_COST` is bumped, the module-load dummy is recomputed at next deploy — no stale-cost oracle.
+
+---
+
+## 3. Rate-limit budgets (audit I11)
+
+### Current best practice
+NIST SP 800-63B-4 §3.2.2 (final, July 2025) requires disabling an authenticator after **100 consecutive failed attempts** on a single account, with progressive throttling permitted to avoid lockout. Rate-limit middleware alone does *not* satisfy this — you also need a persistent per-account fail counter. OWASP API Top 10 2023 (API4), the Authentication Cheat Sheet, Cloudflare's WAF reference rules, and Auth0's production defaults converge on dual-keyed limits: IP + target identifier. IP-only is bypassable by botnets; identifier-only enables targeted DoS. Response is HTTP 429 + `Retry-After` (RFC 9110 §10.2.3) + draft-7 `RateLimit-*` headers.
+
+### Recommended implementation
+| Endpoint | IP key | Identifier key | Notes |
+|---|---|---|---|
+| `POST /login` | 10 fails / 10 min | 10 fails / hour (lowercased username) | `skipSuccessfulRequests: true` |
+| `POST /register` | 5 / hour | — | |
+| `POST /forgot-password` | 5 / hour | 3 / hour (email) | Highest risk: triggers email send |
+| `POST /change-password` | 10 / hour | 5 / hour (userId) | bcrypt pins event loop |
+| `POST /comments` | — | 5 / 10 s burst + 60 / hour sustained | Authenticated |
+| `GET /api/v1/graph/live` | 10 handshakes / min | Map-based 3/user + 10/IP concurrent caps | See §6 |
+| Admin endpoints | 30 / min | 30 / min (adminId) | Alert on 429s |
+
+```ts
+import rateLimit from 'express-rate-limit';
+app.set('trust proxy', 1); // assert correctness at boot — see pitfalls
+
+const loginLimiter = rateLimit({
+  windowMs: 10 * 60_000,
+  limit: 10,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  skipSuccessfulRequests: true,
+  keyGenerator: (req) => req.ip,
+});
+
+const loginUserLimiter = rateLimit({
+  windowMs: 60 * 60_000,
+  limit: 10,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  skipSuccessfulRequests: true,
+  keyGenerator: (req) => (req.body?.username ?? '').toLowerCase().trim() || req.ip,
+});
+
+app.post('/login', loginLimiter, loginUserLimiter, loginHandler);
+```
+
+**Add a persistent per-account fail counter** in SQLite (separate from the rate limiter — the limiter handles windowed brute force, the counter handles distributed low-and-slow per NIST §3.2.2). Reset on successful login. At 100 consecutive fails, require password reset.
+
+### Citations
+- https://pages.nist.gov/800-63-4/sp800-63b.html
+- https://owasp.org/API-Security/editions/2023/en/0xa4-unrestricted-resource-consumption/
+- https://developers.cloudflare.com/waf/rate-limiting-rules/best-practices/
+- https://datatracker.ietf.org/doc/html/rfc9110#section-10.2.3
+- https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers
+- https://express-rate-limit.mintlify.app/overview
+
+### Codebase-specific notes
+- **The #1 silent failure is forgetting `app.set('trust proxy', ...)`** — without it, `req.ip` is the proxy address and all users share one bucket. Add a boot-time assertion that hits an internal echo route from a known external IP.
+- `express-rate-limit`'s `MemoryStore` is fine for single-process Bun (~40 MB / 1M IPs/hour). Document: "Move to `rate-limit-redis` before horizontal scaling — otherwise effective limits become N× per process."
+- Do not persist counters in the main SQLite DB synchronously — every limited request becomes a write tx and starves WAL checkpoints. Use a Map with periodic GC, or a separate SQLite file with `PRAGMA synchronous=NORMAL`.
+- bcrypt cost 12 is ~300 ms of synchronous CPU. Five concurrent `/login` or `/change-password` requests can pin the Bun event loop. Pair the rate limiter with a per-user in-flight semaphore.
+- Pin `standardHeaders: 'draft-7'` explicitly (not `true`) so future package upgrades don't silently flip header shape.
+
+---
+
+## 4. CSRF defence-in-depth (audit I1)
+
+### Current best practice
+SameSite=Lax is defence-in-depth, not a primary CSRF defence (OWASP, MDN, PortSwigger). The 2025–2026 shift: OWASP and MDN now list `Sec-Fetch-Site` as a complete primary defence for modern-browser-only audiences, *with a mandatory Origin/Referer fallback for legacy clients*. Rails 8.2 (`:header_only` default, PR #56350) and Datasette (Go 1.25-inspired, Aug 2025) have adopted this model and dropped form tokens. Synchroniser tokens remain valid but are pure ceremony when there are no HTML forms.
+
+### Recommended implementation
+Stateless gate as Express 5 middleware mounted at the top of the mutating router. Reject `Sec-Fetch-Site: none` on state-changing routes (matching Rails 8.2's `:header_only` default — `none` covers GET address-bar navigations, not POST/PUT/PATCH/DELETE).
+
+```ts
+const ALLOWED_ORIGINS = new Set([process.env.BASE_URL, /* dev variants */]);
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export function csrfGate(req, res, next) {
+  if (SAFE_METHODS.has(req.method)) return next();
+  const sfs = req.get('Sec-Fetch-Site');
+  if (sfs) {
+    if (sfs === 'same-origin' || sfs === 'same-site') return next();
+    return res.status(403).json({ error: 'csrf_blocked' });
+  }
+  // Legacy fallback: Origin then Referer
+  const origin = req.get('Origin') ?? (req.get('Referer') ? new URL(req.get('Referer')!).origin : null);
+  if (origin && ALLOWED_ORIGINS.has(origin)) return next();
+  return res.status(403).json({ error: 'csrf_blocked' });
+}
+```
+
+Additional hardening:
+- Rename auth cookie to `__Host-session` (`Secure`, `Path=/`, no `Domain`, `SameSite=Lax`). Blocks sibling-subdomain cookie injection per RFC 6265bis.
+- **Restrict mutating endpoints to `application/json` only** — forces a CORS preflight on cross-origin attempts. Reject `text/plain` and `x-www-form-urlencoded` bodies on POST/PUT/PATCH/DELETE.
+- Audit every GET handler for state-changing side effects (logout-via-GET, action links). SameSite=Lax sends cookies on top-level GET — this is the highest-payoff fix and is often skipped.
+- Exempt `/webhooks/*` and `/api/health` from the gate; webhooks use HMAC signature verification instead.
+- Verify the reverse proxy (Caddy/Nginx) forwards `Sec-Fetch-Site`, `Origin`, `Referer` untouched — add an integration test.
+
+### Citations
+- https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+- https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/CSRF_prevention
+- https://portswigger.net/web-security/csrf/bypassing-samesite-restrictions
+- https://simonwillison.net/2026/Apr/14/replace-token-based-csrf/
+
+### Codebase-specific notes
+- No synchroniser tokens — pure JSON API consumed by Next.js fetch with `credentials: true`.
+- Do not promote auth cookie to `SameSite=Strict` without verifying magic-link/OAuth callback flows; MDN recommends Lax for auth cookies.
+- Confirm no `method-override` middleware in the stack — if added later, ensure the CSRF gate runs first.
+- Allowlist is exact-match on scheme+host+port, never suffix-match on eTLD+1.
+
+---
+
+## 5. Password length, normalisation, bcrypt 72-byte (audit I22)
+
+### Current best practice
+**NIST SP 800-63B-4 final (Aug 2025) specifies NFC**, not NFKC. NFKC/NFKD appeared in the Second Public Draft and was changed back to NFC in the final publication — the audit's "NFC" wording is correct, contrary to some online summaries. Other final-spec requirements: minimum 15 characters when password is the sole authenticator, support at least 64, screen against a breach corpus (SHALL, raised from SHOULD in Rev 4), no composition rules, no rotation. OWASP Password Storage Cheat Sheet: bcrypt minimum cost 10; verify under 1 second; pre-hash to escape the 72-byte cap using `HMAC-SHA-384` with a pepper (not raw SHA-512 — vulnerable to password shucking and null-byte truncation). Argon2id (RFC 9106) is OWASP's preferred KDF.
+
+### Recommended implementation
+**Migrate to Argon2id via `Bun.password`** — native libsodium, async off-thread, no 72-byte cap, no shucking, no null-byte bug. Keep bcrypt `verify` for legacy hashes, lazy-rehash on next successful login.
+
+```ts
+// auth/password.ts
+const MIN_LEN = 15;
+const MAX_LEN = 128;
+
+export function normalizePassword(raw: string): string {
+  return raw.normalize('NFC'); // NIST 800-63B-4 final, Memorized Secret Verifiers
+}
+
+export async function hashPassword(raw: string): Promise<string> {
+  if (raw.length < MIN_LEN || raw.length > MAX_LEN) throw new Error('invalid_length');
+  const normalized = normalizePassword(raw);
+  if (normalized.length > MAX_LEN) throw new Error('invalid_length_post_normalize');
+  return Bun.password.hash(normalized, {
+    algorithm: 'argon2id',
+    memoryCost: 19456, // OWASP minimum: 19 MiB
+    timeCost: 2,
+  });
+}
+
+export async function verifyPassword(raw: string, hash: string): Promise<boolean> {
+  return Bun.password.verify(normalizePassword(raw), hash); // auto-detects $2b$ vs $argon2id$
+}
+```
+
+Add HIBP k-anonymity check on **register and change-password only** (not login — registration-time check, not session check):
+
+```ts
+import { createHash } from 'node:crypto';
+
+export async function isPwned(raw: string): Promise<boolean> {
+  const sha1 = createHash('sha1').update(normalizePassword(raw)).digest('hex').toUpperCase();
+  const prefix = sha1.slice(0, 5);
+  const suffix = sha1.slice(5);
+  const r = await fetch(`https://api.pwnedpasswords.com/range/${prefix}`, {
+    headers: { 'Add-Padding': 'true' },
+  });
+  if (!r.ok) return false; // fail-open + alert metric
+  const body = await r.text();
+  return body.split('\n').some((line) => line.startsWith(suffix));
+}
+```
+
+### Citations
+- https://pages.nist.gov/800-63-4/sp800-63b.html
+- https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63B-4.pdf
+- https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+- https://datatracker.ietf.org/doc/html/rfc9106
+- https://bun.com/docs/runtime/hashing
+- https://haveibeenpwned.com/Passwords
+- https://www.troyhunt.com/understanding-have-i-been-pwneds-use-of-sha-1-and-k-anonymity/
+
+### Codebase-specific notes
+- Use `Bun.password` (libsodium-backed), not npm `argon2` or `bcryptjs` — those conflict with Bun's runtime thread pool.
+- NFC must run on both register AND login — unit-test with `U+FB01` (ﬁ ligature) and a Korean syllable.
+- HIBP: cache 24 h, fail-open on network error with an alerting metric. Add the `Add-Padding: true` header to defeat traffic-analysis side-channels.
+- Validate raw length → NFC normalise → re-check post-normalisation length → hash. Normalisation can change byte length.
+- If staying on bcrypt instead of migrating: cost 10 minimum (OWASP) is acceptable; cost 12 is a project-specific tuning choice that requires benchmarking on the production VPS, not an OWASP requirement.
+
+---
+
+## 6. SSE security (audit B4)
+
+### Current best practice
+Authenticate SSE via the same cookie middleware as other routes — `EventSource` attaches cookies automatically for same-origin. Validate `Origin` as CSRF defence (SSE is a GET). Heartbeat with an SSE comment line (`:hb\n\n`) every 15–30 s (~25 s is the median) to defeat idle-proxy timeouts. Cap concurrent connections per user and per IP via an in-process `Map`, not `express-rate-limit` (which counts requests, not open streams). Rate-limit the *handshake*, not message rate. Tokens in URLs are an OWASP-flagged information-exposure pattern — short-lived (≤120 s) signed handshake JWTs are the documented carve-out when cross-origin cookies are impossible.
+
+### Recommended implementation
+```ts
+import { randomUUID } from 'node:crypto';
+
+const connections = new Map<number, Set<{ id: string; res: Response }>>();
+const PER_USER_CAP = 3; // well under browser HTTP/1.1 6-per-origin
+const PER_IP_CAP = 10;
+
+app.get('/api/v1/graph/live', authenticate(), csrfGate, handshakeLimiter, (req, res) => {
+  const userId = req.user!.id;
+  const userSet = connections.get(userId) ?? new Set();
+  if (userSet.size >= PER_USER_CAP) {
+    res.set('Retry-After', '30');
+    return res.status(429).json({ error: 'too_many_sse_connections' });
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+
+  const id = randomUUID();
+  const entry = { id, res };
+  userSet.add(entry);
+  connections.set(userId, userSet);
+
+  const hb = setInterval(() => res.write(':hb\n\n'), 25_000);
+
+  let closed = false;
+  const onClose = () => {
+    if (closed) return;
+    closed = true;
+    clearInterval(hb);
+    userSet.delete(entry);
+    if (userSet.size === 0) connections.delete(userId);
+    if (!res.writableEnded) { try { res.end(); } catch {} }
+  };
+  req.on('close', onClose);
+  res.on('close', onClose);
+});
+```
+
+### Citations
+- https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
+- https://owasp.org/www-community/vulnerabilities/Information_exposure_through_query_strings_in_url
+- https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
+- https://bun.com/reference/node/crypto/randomUUID
+- https://bun.com/docs/runtime/nodejs-compat
+
+### Codebase-specific notes
+- Use `import { randomUUID } from 'node:crypto'` (lint-safe, no `no-undef`, Bun-compatible) over `globalThis.crypto.randomUUID()`.
+- Per-user cap = 3: leaves browser HTTP/1.1 budget for other XHR/asset connections on the same origin.
+- Close handler must be idempotent (the `closed` flag) — `req.on('close')` and `res.on('close')` can both fire; Bun throws on post-close `res.end()` without the guard.
+- Do NOT debounce SSE writes with per-message Drizzle queries — coalesce with one shared poller fanning out across the connection Map.
+- Verify the reverse proxy (Cloudflare buffers SSE on free tier; nginx needs `X-Accel-Buffering: no`).
+- Add a CI/lint gate failing on `req.query.token` in any auth-bearing route — prevents the "temporary fix" rule violation.
+- Add `SIGTERM` handler that walks the Map and `res.end()`s each entry for clean PM2/Bun reloads.
+
+---
+
+## 7. SQLite backup durability (audit I8, I9, I10)
+
+### Current best practice
+2026 canonical stack: **Litestream v0.5.x** streams WAL frames in LTX format with hierarchical compaction (30 s / 5 min / 1 h levels), giving sub-second-lag PITR from a dozen files. Offsite target: **Backblaze B2** (~$0.006/GB) fronted by Cloudflare for free egress via Bandwidth Alliance; Cloudflare R2 if you want unconditional zero egress single-vendor. Verify with `PRAGMA integrity_check` AND `PRAGMA foreign_key_check` (the former does not cover FK constraints). Run a monthly end-to-end restore drill in CI — verifying the artifact exists is not the same as verifying you can recover. GFS retention: 7 daily / 4 weekly / 12 monthly / 3-7 yearly. Encrypt snapshot tarballs with **age** (X25519 + ChaCha20-Poly1305) plus bucket SSE.
+
+### Recommended implementation
+1. **Litestream as primary continuous replication** to B2. Lifecycle: "keep only the last version" (Litestream files are immutable; bucket versioning silently doubles cost).
+2. **Daily snapshot via `scripts/backup-db.sh`** (encrypted with age, GFS-retained). `backup-db.yml` invokes the script (`uses: ./scripts/backup-db.sh`) instead of re-implementing — fixes I10.
+3. **Verification gates in `backup-db.sh`** before upload:
+   ```bash
+   sqlite3 /tmp/restore-test.db 'PRAGMA integrity_check;' | grep -qx ok || exit 1
+   sqlite3 /tmp/restore-test.db 'PRAGMA foreign_key_check;' | wc -l | grep -qx 0 || exit 1
+   gunzip -t snapshot.db.gz || exit 1
+   ```
+4. **Monthly CI restore drill**: download latest Litestream replica into a scratch container, run integrity_check + a row-count sanity query, alert on failure. This closes I9.
+5. **Named Docker volume** in prod (not host bind-mount) — Linux ext4 bind-mounts work fine in prod, but use a named volume regardless for consistency.
+6. **Never `cp` the bare `.db`** without `-wal` and `-shm`. Always go through SQLite Backup API, `VACUUM INTO`, or Litestream. Document in script header.
+7. Keep age identity file off the prod host (1Password, GitHub Actions secret, hardware key). Only the public recipient lives on the host. Consider age v1.2+ `-pq` hybrid mode for yearly grandfather snapshots given long retention.
+
+### Citations
+- https://litestream.io/
+- https://fly.io/blog/litestream-v050-is-here/
+- https://litestream.io/guides/backblaze/
+- https://sqlite.org/backup.html
+- https://sqlite.org/pragma.html
+- https://age-encryption.org/
+- https://www.backblaze.com/blog/better-backup-practices-what-is-the-grandfather-father-son-approach/
+
+### Codebase-specific notes
+- App-boot PRAGMA block: `PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;` — Litestream cannot stream incrementally without WAL.
+- `backup-db.sh` and Litestream must not both checkpoint simultaneously — use `VACUUM INTO` in the snapshot script to avoid touching WAL semantics.
+- Drizzle long-running transactions delay WAL checkpoints, affecting Litestream compaction. Keep transactions short.
+- B2 S3 API has a 5 MB minimum part size — Litestream defaults handle this; only matters if customising.
+- Cloudflare R2 has no egress but charges Class A/B operations — chatty WAL frame uploads can make ops cost exceed storage cost. Tune `monitor-interval`.
+
+---
+
+## 8. Drizzle transactions / race conditions (audit I13, I14, I36)
+
+### Current best practice
+SQLite is single-writer; in WAL mode at most one write transaction holds the write lock. **Drizzle's default transaction behaviour is `deferred`** (matching better-sqlite3 default) — a deferred tx takes only a read lock at BEGIN and upgrades on first write, producing the exact lost-update race and mid-tx `SQLITE_BUSY` errors the audit aims to fix. **Wrapping in `db.transaction()` alone does not fix the race.** `BEGIN IMMEDIATE` claims the RESERVED write lock at BEGIN, eliminating the read-then-upgrade window. SQLite does not expose `isolation_level` knobs — `behavior: 'deferred' | 'immediate' | 'exclusive'` is the only lever. For toggle/counter patterns, a single `INSERT … ON CONFLICT … DO UPDATE` is race-free inside the engine (requires a real UNIQUE constraint).
+
+### Recommended implementation
+**Connection-open PRAGMAs (once, in `db.ts`):**
+```ts
+db.exec(`
+  PRAGMA journal_mode = WAL;
+  PRAGMA synchronous = NORMAL;
+  PRAGMA busy_timeout = 5000;
+  PRAGMA foreign_keys = ON;
+  PRAGMA cache_size = -20000;
+`);
+```
+
+**I13 (MAX_SESSIONS cap)** — collapse to two statements in one immediate tx:
+```ts
+await withRetry(() => db.transaction(async (tx) => {
+  await tx.insert(sessions).values({ userId, tokenHash, expiresAt });
+  await tx.run(sql`
+    DELETE FROM sessions
+    WHERE user_id = ${userId}
+      AND id NOT IN (
+        SELECT id FROM sessions WHERE user_id = ${userId}
+        ORDER BY created_at DESC LIMIT ${MAX_SESSIONS}
+      )
+  `);
+}, { behavior: 'immediate' }));
+```
+
+**I14 (reaction toggle)** — requires `UNIQUE(userId, commentId)` as a real CONSTRAINT (not just a Drizzle `uniqueIndex` — see Drizzle #4152). Add/change-type via UPSERT; toggle-off via immediate tx:
+```ts
+// Add or change reaction type
+await db.insert(reactions)
+  .values({ userId, commentId, type })
+  .onConflictDoUpdate({
+    target: [reactions.userId, reactions.commentId],
+    set: { type: sql`excluded.type` },
+  });
+
+// Remove reaction (true toggle off)
+await db.transaction(async (tx) => {
+  await tx.delete(reactions).where(
+    and(eq(reactions.userId, userId), eq(reactions.commentId, commentId))
+  );
+}, { behavior: 'immediate' });
+```
+
+**I36 (admin bulk delete)** — one immediate tx, `IN (...)` not per-row loop. With `ON DELETE CASCADE` and `PRAGMA foreign_keys=ON`, a single parent DELETE is atomic across tables.
+
+**Retry wrapper:**
+```ts
+async function withRetry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+  for (let i = 0; i < attempts; i++) {
+    try { return await fn(); }
+    catch (e: any) {
+      const busy = e.code === 'SQLITE_BUSY' || e.code === 'SQLITE_BUSY_SNAPSHOT';
+      if (!busy || i === attempts - 1) throw e;
+      await new Promise((r) => setTimeout(r, 50 * (i + 1) + Math.random() * 50));
+    }
+  }
+  throw new Error('unreachable');
+}
+```
+
+### Citations
+- https://orm.drizzle.team/docs/transactions
+- https://orm.drizzle.team/docs/guides/upsert
+- https://sqlite.org/lang_transaction.html
+- https://sqlite.org/lang_conflict.html
+- https://sqlite.org/c3ref/busy_timeout.html
+- https://github.com/drizzle-team/drizzle-orm/issues/4152
+- https://github.com/drizzle-team/drizzle-orm/issues/2275
+
+### Codebase-specific notes
+- Confirm whether this project uses `drizzle-orm/bun-sqlite` or `drizzle-orm/better-sqlite3` (check `package.json`). Drizzle issue #2275 documents that async tx callbacks are not properly awaited on `bun-sqlite` — prefer synchronous `tx.run()` calls on that driver.
+- Never `await` non-DB I/O (fetch, queue publish) inside a transaction callback — you hold the global write lock for the duration and starve every other writer.
+- `busy_timeout` only helps for *initial* lock acquisition. Errors surfacing mid-transaction (the deferred-upgrade race) bypass it — another reason for IMMEDIATE.
+- Drizzle's `db.transaction` only rolls back if the callback throws. If you catch internally and don't rethrow, the tx commits partial state. Keep callbacks small and rethrow.
+- Add integration tests: 50 concurrent logins for one userId asserting `sessions.length === MAX_SESSIONS`; N concurrent reaction toggles asserting no duplicate rows. Without these, the fix is unverified.
+
+---
+
+## Implementation order
+
+The order matters because some fixes unblock others:
+
+1. **Connection-open PRAGMAs** (§8) — `journal_mode=WAL`, `busy_timeout=5000`, `foreign_keys=ON`. Cheap, no-risk, pre-requisite for everything else: transactions, Litestream, rate-limit-counter persistence, session storage all depend on these defaults being correct.
+
+2. **CSRF gate + `__Host-` cookie rename + `application/json`-only bodies** (§4) — pure middleware additions, zero schema impact. Doing this *before* the session refactor avoids needing two cookie-rename migrations. Audit GET handlers for side effects here too.
+
+3. **`trust proxy` boot-time assertion + rate-limit middleware skeleton** (§3) — also pure middleware. Doing this *before* the auth refactor means the new login flow lands behind a working limiter from day one. Persistent per-account fail counter can land in a follow-up PR.
+
+4. **Session token hashing at rest** (§1) — schema migration: drop `sessions.token`, add `sessions.tokenHash`, wipe table. Forces one user re-login. Lands cleanly after step 2 because the new `__Host-session` cookie is already in place.
+
+5. **Password normalisation + length bounds + bcrypt-dummy-hash on login** (§2 login half + §5 length/normalisation) — these touch the same code paths. NFC normalisation, schema bounds, and the precomputed dummy bcrypt hash all ship together. Argon2id migration is a follow-up (verifier auto-detects hash type).
+
+6. **Register email-conflict + forgot-password always-202** (§2 register/forgot halves) — depends on having an email-send queue. If the queue is synchronous today, ship the always-202 response first and back-fill async dispatch as a follow-up.
+
+7. **Transaction `{ behavior: 'immediate' }` fixes + UPSERTs + retry wrapper** (§8) — I13, I14, I36. Verify or add the `UNIQUE(userId, commentId)` CONSTRAINT *before* converting the reaction toggle to UPSERT. Add concurrent-request integration tests in the same PR.
+
+8. **SSE hardening** (§6) — `node:crypto` import, `authenticate()`, connection-cap Map, heartbeat, idempotent close handler. Depends on §3 (handshake rate limiter) and §4 (CSRF gate) being mounted.
+
+9. **HIBP k-anonymity on register/change-password** (§5) — additive, depends on §5's normalisation helper. Cache 24 h, fail-open with alert metric.
+
+10. **Argon2id migration via `Bun.password`** (§5) — lazy-rehash on next successful verify. Long tail; deploys safely after §4 cookie rename.
+
+11. **Litestream + B2 + `backup-db.yml` calling `backup-db.sh` + monthly restore drill** (§7) — fully independent of all app changes. Can ship in parallel at any point but is best done *after* the WAL PRAGMAs in step 1 are confirmed in production.
+
+12. **Persistent per-account fail counter for NIST §3.2.2 compliance** (§3) — follow-up to step 3. Separate SQLite file with `synchronous=NORMAL` to avoid contention on the main DB.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# Pin runtime to production. Under Bun, next-mdx-remote and react/jsx-runtime
+# each read process.env.NODE_ENV independently and can disagree if it is unset
+# at module-load time, which causes on-demand MDX rendering to crash with
+# "undefined is not an object (evaluating 'Object.keys(t)')". Pin it here.
+export NODE_ENV=production
+
 # Start the Next.js client
 cd /app/client && bun run start &
 CLIENT_PID=$!

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 set -e
 
-# Pin runtime to production. Under Bun, next-mdx-remote and react/jsx-runtime
-# each read process.env.NODE_ENV independently and can disagree if it is unset
-# at module-load time, which causes on-demand MDX rendering to crash with
-# "undefined is not an object (evaluating 'Object.keys(t)')". Pin it here.
-export NODE_ENV=production
+# BUILD_ENV (local | dev | prod) is the single source of truth for this app.
+# Derive NODE_ENV from it so we never have two env vars to keep in sync:
+#   local → development (matches `next dev` locally; never runs in this script
+#                        in practice, but kept correct for completeness)
+#   dev   → production  (deployed VPS build, production-mode Next runtime)
+#   prod  → production  (deployed VPS build, production-mode Next runtime)
+case "${BUILD_ENV:-prod}" in
+  local) export NODE_ENV=development ;;
+  *)     export NODE_ENV=production ;;
+esac
 
 # Start the Next.js client
 cd /app/client && bun run start &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,10 @@
 #!/bin/sh
 set -e
 
-# BUILD_ENV (local | dev | prod) is the single source of truth for this app.
-# Derive NODE_ENV from it so we never have two env vars to keep in sync:
-#   local → development (matches `next dev` locally; never runs in this script
-#                        in practice, but kept correct for completeness)
-#   dev   → production  (deployed VPS build, production-mode Next runtime)
-#   prod  → production  (deployed VPS build, production-mode Next runtime)
-case "${BUILD_ENV:-prod}" in
-  local) export NODE_ENV=development ;;
-  *)     export NODE_ENV=production ;;
-esac
+# NODE_ENV is pinned to production at Docker build time (see Dockerfile).
+# APP_ENV (local | dev | prod) carries the deploy-target identity and is
+# read by the server config and inlined into the client bundle via
+# NEXT_PUBLIC_APP_ENV. No derivation needed here.
 
 # Start the Next.js client
 cd /app/client && bun run start &

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "derecksnotes.com",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "type": "module",
   "workspaces": [
     "client",

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -3,7 +3,12 @@ set -euo pipefail
 
 # ============================================================
 # SQLite Database Backup Script
-# Safe hot backup using sqlite3 .backup command
+# Safe hot backup using sqlite3 .backup command.
+# Verifies the backup with PRAGMA integrity_check + PRAGMA foreign_key_check
+# before gzipping, and verifies gzip integrity after compression. A backup
+# that silently corrupts can rotate out the last known-good copy before
+# anyone notices the live DB is bad — these checks make the failure loud
+# and synchronous.
 #
 # Usage:
 #   ./backup-db.sh <database-path> <backup-dir> [max-backups]
@@ -66,6 +71,28 @@ fi
 BACKUP_SIZE=$(du -h "$BACKUP_PATH" | cut -f1)
 echo "Backup created: ${BACKUP_SIZE}"
 
+# ---- Verify ----
+
+echo "Verifying backup integrity (PRAGMA integrity_check)..."
+INTEGRITY_RESULT=$(sqlite3 "$BACKUP_PATH" "PRAGMA integrity_check;")
+if [ "$INTEGRITY_RESULT" != "ok" ]; then
+    echo "Error: integrity_check failed:"
+    echo "$INTEGRITY_RESULT"
+    rm -f "$BACKUP_PATH"
+    exit 1
+fi
+echo "  integrity_check: ok"
+
+echo "Verifying foreign keys (PRAGMA foreign_key_check)..."
+FK_RESULT=$(sqlite3 "$BACKUP_PATH" "PRAGMA foreign_key_check;")
+if [ -n "$FK_RESULT" ]; then
+    echo "Error: foreign_key_check failed:"
+    echo "$FK_RESULT"
+    rm -f "$BACKUP_PATH"
+    exit 1
+fi
+echo "  foreign_key_check: ok"
+
 # ---- Compress ----
 
 echo "Compressing..."
@@ -76,8 +103,15 @@ if [ ! -f "$COMPRESSED_PATH" ]; then
     exit 1
 fi
 
+echo "Verifying gzip integrity (gunzip -t)..."
+if ! gunzip -t "$COMPRESSED_PATH"; then
+    echo "Error: gzip test failed:"
+    rm -f "$COMPRESSED_PATH"
+    exit 1
+fi
+
 COMPRESSED_SIZE=$(du -h "$COMPRESSED_PATH" | cut -f1)
-echo "Compressed: ${COMPRESSED_SIZE}"
+echo "Compressed: ${COMPRESSED_SIZE} (verified)"
 
 # ---- Rotate old backups ----
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -7,7 +7,15 @@ APP_ENV=local
 # Session signing key. Generate with: openssl rand -base64 32
 SESSION_SECRET=
 
-# This username gets auto-elevated to admin on registration.
+# Optional pepper for the session-token hash in the database. If set, the DB
+# stores HMAC-SHA256(pepper, token) instead of plain SHA-256(token). Rotating
+# this value invalidates every live session — that's intended. Generate with:
+# openssl rand -base64 32
+SESSION_TOKEN_PEPPER=
+
+# This username is auto-elevated to admin the first time the matching user
+# registers (case-sensitive). Required for a fresh database to ever have an
+# admin; existing databases that already have an admin can leave this blank.
 ADMIN_USERNAME=
 
 # Optional overrides

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,8 +1,8 @@
 # Server environment variables
-# Only BUILD_ENV and SESSION_SECRET are required.
+# Only APP_ENV and SESSION_SECRET are required.
 
 # Environment: local | dev | prod
-BUILD_ENV=local
+APP_ENV=local
 
 # Session signing key. Generate with: openssl rand -base64 32
 SESSION_SECRET=

--- a/server/README.md
+++ b/server/README.md
@@ -61,7 +61,7 @@ bun run db:studio    # Browse database
 ```env
 SESSION_SECRET=your-secret-key
 ADMIN_USERNAME=your_admin_username
-BUILD_ENV=local  # local | dev | prod
+APP_ENV=local  # local | dev | prod
 ```
 
 ## Permission Groups

--- a/server/drizzle/0002_session_token_hash.sql
+++ b/server/drizzle/0002_session_token_hash.sql
@@ -1,0 +1,20 @@
+-- I3: store SHA-256 (or HMAC-SHA256 with SESSION_TOKEN_PEPPER) of the
+-- session cookie value instead of the raw token. A DB compromise after this
+-- migration cannot resume any live session.
+--
+-- No backwards-compat: there are no production users yet. Existing rows
+-- (mostly seed/dev) are dropped; users re-login on next visit.
+
+DROP INDEX IF EXISTS `sessions_token_unique`;--> statement-breakpoint
+DROP TABLE `sessions`;--> statement-breakpoint
+CREATE TABLE `sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`user_agent` text,
+	`ip_address` text,
+	`created_at` text NOT NULL,
+	`expires_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);--> statement-breakpoint
+CREATE UNIQUE INDEX `sessions_token_hash_unique` ON `sessions` (`token_hash`);

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775272491216,
       "tag": "0001_free_invisible_woman",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1781552400000,
+      "tag": "0002_session_token_hash",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -3,7 +3,16 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { migrate } from 'drizzle-orm/bun-sqlite/migrator';
 import { config } from '@lib/env';
 import * as path from 'path';
+import * as fs from 'fs';
 import * as schema from './schema';
+
+// Ensure the parent directory exists before opening — otherwise SQLite
+// throws SQLITE_CANTOPEN on first import in any context that doesn't
+// pre-create it (CI runners, fresh dev clones, ephemeral containers).
+// The same mkdir lived in server/src/index.ts; pulling it here means any
+// caller of @db/index (tests, scripts) gets it for free.
+const dbDir = path.dirname(config.databasePath);
+if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true });
 
 export const sqlite = new Database(config.databasePath);
 sqlite.exec('PRAGMA journal_mode = WAL;');

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -28,7 +28,10 @@ export const sessions = sqliteTable('sessions', {
   userId: text('user_id')
     .notNull()
     .references(() => users.id),
-  token: text('token').notNull().unique(),
+  // SHA-256 (optionally HMAC'd with SESSION_TOKEN_PEPPER) of the raw cookie
+  // value. The raw token is never persisted; lookup is by hash. A DB compromise
+  // therefore cannot resume live sessions.
+  tokenHash: text('token_hash').notNull().unique(),
   userAgent: text('user_agent'),
   ipAddress: text('ip_address'),
   createdAt: text('created_at').notNull(),

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -286,7 +286,7 @@ async function seed() {
       updatedAt: daysAgo(45)
     },
     {
-      id: userIds[0],
+      id: userIds[0]!,
       username: 'new_user_sam',
       email: null,
       passwordHash,
@@ -296,7 +296,7 @@ async function seed() {
       updatedAt: daysAgo(5)
     },
     {
-      id: userIds[1],
+      id: userIds[1]!,
       username: 'science_nerd',
       email: 'nerd@example.com',
       passwordHash,
@@ -306,7 +306,7 @@ async function seed() {
       updatedAt: daysAgo(30)
     },
     {
-      id: userIds[2],
+      id: userIds[2]!,
       username: 'code_monkey',
       email: null,
       passwordHash,
@@ -316,7 +316,7 @@ async function seed() {
       updatedAt: daysAgo(20)
     },
     {
-      id: userIds[3],
+      id: userIds[3]!,
       username: 'bookworm_42',
       email: 'books@example.com',
       passwordHash,
@@ -326,7 +326,7 @@ async function seed() {
       updatedAt: daysAgo(15)
     },
     {
-      id: userIds[4],
+      id: userIds[4]!,
       username: 'banned_troll',
       email: null,
       passwordHash,
@@ -356,7 +356,7 @@ async function seed() {
   // Ban the troll
   await db.insert(schema.userBans).values({
     id: id(),
-    userId: userIds[4],
+    userId: userIds[4]!,
     bannedBy: adminId,
     reason: 'Spam and harassment',
     createdAt: daysAgo(10)
@@ -403,7 +403,7 @@ async function seed() {
     // Post 1 - async programming
     {
       id: id(),
-      postId: posts[0].id,
+      postId: posts[0]!.id,
       userId: trustedId,
       content:
         "Great article! I never thought about using **async patterns** in R like this. The comparison with JavaScript's `Promise.all()` was really helpful.",
@@ -413,8 +413,8 @@ async function seed() {
     },
     {
       id: id(),
-      postId: posts[0].id,
-      userId: userIds[1],
+      postId: posts[0]!.id,
+      userId: userIds[1]!,
       content:
         'This is exactly what I needed for my bioinformatics pipeline. Processing multiple FASTA files concurrently is a game changer.',
       depth: 0,
@@ -423,8 +423,8 @@ async function seed() {
     },
     {
       id: id(),
-      postId: posts[0].id,
-      userId: userIds[2],
+      postId: posts[0]!.id,
+      userId: userIds[2]!,
       content:
         'As a JS dev learning R, this bridged a huge gap for me. Would love to see a follow-up on error handling in async R.',
       depth: 0,
@@ -434,8 +434,8 @@ async function seed() {
     // Post 2 - bioinformatics
     {
       id: id(),
-      postId: posts[1].id,
-      userId: userIds[1],
+      postId: posts[1]!.id,
+      userId: userIds[1]!,
       content:
         'This cheat sheet is incredible. Bookmarked for daily reference. The section on **sequence alignment** algorithms is particularly well-written.',
       depth: 0,
@@ -444,7 +444,7 @@ async function seed() {
     },
     {
       id: id(),
-      postId: posts[1].id,
+      postId: posts[1]!.id,
       userId: trustedId,
       content:
         'One small correction: BLAST uses a heuristic approach, not dynamic programming directly. The E-value explanation is spot on though.',
@@ -455,7 +455,7 @@ async function seed() {
     },
     {
       id: id(),
-      postId: posts[1].id,
+      postId: posts[1]!.id,
       userId: modId,
       content:
         'Pinning this as a community resource. Really well done, Dereck.',
@@ -468,8 +468,8 @@ async function seed() {
     // Post 3 - canvases
     {
       id: id(),
-      postId: posts[2].id,
-      userId: userIds[2],
+      postId: posts[2]!.id,
+      userId: userIds[2]!,
       content:
         'The Canvas API examples are clean. I used this approach in my portfolio site. One question: how do you handle **retina displays** with canvas?',
       depth: 0,
@@ -478,8 +478,8 @@ async function seed() {
     },
     {
       id: id(),
-      postId: posts[2].id,
-      userId: userIds[3],
+      postId: posts[2]!.id,
+      userId: userIds[3]!,
       content:
         'Beautiful visualizations! Is there a performance comparison between Canvas and SVG for the kind of animations shown here?',
       depth: 0,
@@ -489,8 +489,8 @@ async function seed() {
     // Pending comments (from new users)
     {
       id: id(),
-      postId: posts[0].id,
-      userId: userIds[0],
+      postId: posts[0]!.id,
+      userId: userIds[0]!,
       content:
         'Thanks for this tutorial! Quick question: does this work with R version 4.3?',
       depth: 0,
@@ -499,8 +499,8 @@ async function seed() {
     },
     {
       id: id(),
-      postId: posts[1].id,
-      userId: userIds[0],
+      postId: posts[1]!.id,
+      userId: userIds[0]!,
       content:
         'Could you add a section on _proteomics_ workflows? That would make this guide even more complete.',
       depth: 0,
@@ -509,8 +509,8 @@ async function seed() {
     },
     {
       id: id(),
-      postId: posts[2].id,
-      userId: userIds[0],
+      postId: posts[2]!.id,
+      userId: userIds[0]!,
       content:
         'I tried the code examples but got an error. Is `CanvasRenderingContext2D` supported in all browsers?',
       depth: 0,
@@ -520,7 +520,7 @@ async function seed() {
     // Demo page comments
     {
       id: id(),
-      postId: posts[4].id,
+      postId: posts[4]!.id,
       userId: adminId,
       content:
         'This is a test comment on the **demo page**. Everything seems to be working!',
@@ -530,7 +530,7 @@ async function seed() {
     },
     {
       id: id(),
-      postId: posts[4].id,
+      postId: posts[4]!.id,
       userId: trustedId,
       content: 'Confirmed — comments with `markdown` rendering look great.',
       depth: 0,
@@ -547,9 +547,9 @@ async function seed() {
     // Reply to first comment on post 1
     {
       id: reply1Id,
-      postId: posts[0].id,
+      postId: posts[0]!.id,
       userId: adminId,
-      parentId: commentData[0].id,
+      parentId: commentData[0]!.id,
       content:
         "Thanks! I'm planning a follow-up on error handling. Stay tuned.",
       depth: 1,
@@ -559,7 +559,7 @@ async function seed() {
     // Reply to the reply
     {
       id: id(),
-      postId: posts[0].id,
+      postId: posts[0]!.id,
       userId: trustedId,
       parentId: reply1Id,
       content: 'Looking forward to it! Will you cover `tryCatch` patterns too?',
@@ -570,9 +570,9 @@ async function seed() {
     // Reply on post 2
     {
       id: id(),
-      postId: posts[1].id,
+      postId: posts[1]!.id,
       userId: adminId,
-      parentId: commentData[4].id,
+      parentId: commentData[4]!.id,
       content:
         "Good catch on the BLAST detail! I've updated the article. Thanks for the correction.",
       depth: 1,
@@ -582,9 +582,9 @@ async function seed() {
     // Reply on canvas post
     {
       id: id(),
-      postId: posts[2].id,
+      postId: posts[2]!.id,
       userId: adminId,
-      parentId: commentData[6].id,
+      parentId: commentData[6]!.id,
       content:
         "For retina: use `window.devicePixelRatio` to scale the canvas. I'll add an example to the article.",
       depth: 1,
@@ -594,9 +594,9 @@ async function seed() {
     // Reply on demo page
     {
       id: id(),
-      postId: posts[4].id,
+      postId: posts[4]!.id,
       userId: modId,
-      parentId: commentData[11].id,
+      parentId: commentData[11]!.id,
       content: 'Looks good! The threading works nicely.',
       depth: 1,
       approved: 1,
@@ -609,7 +609,7 @@ async function seed() {
   // Comment history for the edited comment
   await db.insert(schema.commentHistory).values({
     id: id(),
-    commentId: commentData[4].id,
+    commentId: commentData[4]!.id,
     content:
       'One small correction: BLAST uses a heuristic approach, not dynamic programming. The E-value explanation is spot on though.',
     editedAt: daysAgo(37),
@@ -636,7 +636,7 @@ async function seed() {
         reactionInserts.push({
           id: id(),
           commentId: c.id,
-          userId: shuffled[i],
+          userId: shuffled[i]!,
           type: 'like',
           createdAt: c.createdAt
         });
@@ -683,7 +683,7 @@ async function seed() {
       readInserts.push({
         id: id(),
         userId: uid,
-        postId: shuffledPosts[i].id,
+        postId: shuffledPosts[i]!.id,
         readAt: daysAgo(Math.floor(Math.random() * 30))
       });
     }
@@ -697,7 +697,7 @@ async function seed() {
       adminId,
       action: 'comment.approve',
       targetType: 'comment',
-      targetId: commentData[0].id,
+      targetId: commentData[0]!.id,
       details: JSON.stringify({ username: 'trusted_alex' }),
       ipAddress: '192.168.1.1',
       createdAt: daysAgo(55)
@@ -707,7 +707,7 @@ async function seed() {
       adminId,
       action: 'comment.approve',
       targetType: 'comment',
-      targetId: commentData[1].id,
+      targetId: commentData[1]!.id,
       details: JSON.stringify({ username: 'science_nerd' }),
       ipAddress: '192.168.1.1',
       createdAt: daysAgo(50)
@@ -727,7 +727,7 @@ async function seed() {
       adminId,
       action: 'user.ban',
       targetType: 'user',
-      targetId: userIds[4],
+      targetId: userIds[4]!,
       details: JSON.stringify({
         username: 'banned_troll',
         reason: 'Spam and harassment'
@@ -740,7 +740,7 @@ async function seed() {
       adminId: modId,
       action: 'comment.approve',
       targetType: 'comment',
-      targetId: commentData[6].id,
+      targetId: commentData[6]!.id,
       details: JSON.stringify({ username: 'code_monkey' }),
       ipAddress: '10.0.0.5',
       createdAt: daysAgo(25)
@@ -750,7 +750,7 @@ async function seed() {
       adminId: modId,
       action: 'comment.approve',
       targetType: 'comment',
-      targetId: commentData[7].id,
+      targetId: commentData[7]!.id,
       details: JSON.stringify({ username: 'bookworm_42' }),
       ipAddress: '10.0.0.5',
       createdAt: daysAgo(22)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,7 +26,7 @@ app.use(express.json({ limit: '100kb' }));
 app.use(cookieParser());
 app.use(
   cors({
-    origin: config.buildEnv === 'local' ? true : config.baseUrl,
+    origin: config.appEnv === 'local' ? true : config.baseUrl,
     credentials: true
   })
 );
@@ -39,7 +39,7 @@ app.get('/api', (_req, res) => {
     name: 'derecksnotes-api',
     version: '6.0.0',
     status: 'ok',
-    environment: config.buildEnv
+    environment: config.appEnv
   });
 });
 
@@ -80,5 +80,5 @@ try {
 
 app.listen(config.port, () => {
   console.log(`API server running at http://localhost:${config.port}`);
-  console.log(`Environment: ${config.buildEnv}`);
+  console.log(`Environment: ${config.appEnv}`);
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,7 @@ import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import { config } from '@lib/env';
 import { generalLimiter } from '@middleware/rateLimit';
+import { csrfGuard } from '@middleware/csrf';
 import v1Routes from '@routes/index';
 import { db, schema } from '@db/index';
 import { buildSearchIndex } from '@services/search';
@@ -32,6 +33,9 @@ app.use(
 );
 
 app.use('/api', generalLimiter);
+// CSRF guard mounted only on /api/v1 — leaves health + root info untouched
+// so monitoring tools (which don't send Origin) keep working.
+app.use('/api/v1', csrfGuard());
 
 // API info
 app.get('/api', (_req, res) => {

--- a/server/src/lib/env.ts
+++ b/server/src/lib/env.ts
@@ -1,26 +1,26 @@
 import path from 'path';
-import { ENV_CONFIG, type BuildEnv } from '@derecksnotes/shared';
+import { ENV_CONFIG, type AppEnv } from '@derecksnotes/shared';
 
-const VALID_BUILD_ENVS = ['local', 'dev', 'prod'] as const;
+const VALID_APP_ENVS = ['local', 'dev', 'prod'] as const;
 
-function resolveBuildEnv(): BuildEnv {
-  const raw = process.env.BUILD_ENV;
+function resolveAppEnv(): AppEnv {
+  const raw = process.env.APP_ENV;
   if (raw === undefined) {
     // Default to 'local' only when truly unset. Make it explicit and noisy.
     console.warn(
-      "[env] BUILD_ENV is not set; defaulting to 'local'. Set BUILD_ENV=local|dev|prod explicitly for non-dev environments."
+      "[env] APP_ENV is not set; defaulting to 'local'. Set APP_ENV=local|dev|prod explicitly for non-dev environments."
     );
     return 'local';
   }
-  if (!(VALID_BUILD_ENVS as readonly string[]).includes(raw)) {
+  if (!(VALID_APP_ENVS as readonly string[]).includes(raw)) {
     throw new Error(
-      `[env] Invalid BUILD_ENV='${raw}'. Must be one of: ${VALID_BUILD_ENVS.join(', ')}`
+      `[env] Invalid APP_ENV='${raw}'. Must be one of: ${VALID_APP_ENVS.join(', ')}`
     );
   }
-  return raw as BuildEnv;
+  return raw as AppEnv;
 }
 
-const BUILD_ENV = resolveBuildEnv();
+const APP_ENV = resolveAppEnv();
 const SERVER_DIR = path.resolve(import.meta.dir, '../..');
 
 const SERVER_CONFIG = {
@@ -38,12 +38,12 @@ const SERVER_CONFIG = {
   }
 } as const;
 
-const derived = ENV_CONFIG[BUILD_ENV];
-const serverDerived = SERVER_CONFIG[BUILD_ENV];
+const derived = ENV_CONFIG[APP_ENV];
+const serverDerived = SERVER_CONFIG[APP_ENV];
 
 export const config = {
-  buildEnv: BUILD_ENV,
-  isProduction: BUILD_ENV === 'prod',
+  appEnv: APP_ENV,
+  isProduction: APP_ENV === 'prod',
   port: parseInt(process.env.PORT || '3001', 10),
   domain: derived.domain,
   baseUrl: derived.baseUrl,
@@ -56,7 +56,7 @@ export const config = {
 
 // Invariant: production must always emit Secure cookies. Refuse to start
 // the process in an inconsistent state (e.g., production deploy with
-// BUILD_ENV accidentally set to 'local').
+// APP_ENV accidentally set to 'local').
 if (config.isProduction && !config.secureCookies) {
   throw new Error(
     '[env] Inconsistent configuration: isProduction=true but secureCookies=false. Refusing to start.'
@@ -70,7 +70,7 @@ export const secrets = {
 function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) {
-    if (BUILD_ENV === 'local') {
+    if (APP_ENV === 'local') {
       console.warn(
         `Warning: Missing ${name} — using placeholder for local dev`
       );

--- a/server/src/lib/env.ts
+++ b/server/src/lib/env.ts
@@ -63,6 +63,18 @@ if (config.isProduction && !config.secureCookies) {
   );
 }
 
+// Loud warning if a non-local deploy has no ADMIN_USERNAME — a fresh DB will
+// have zero admins, locking the dashboard. The bootstrap is implemented in
+// services/users.ts: a registration with username === ADMIN_USERNAME is
+// auto-elevated to the admin group. Warn only — don't refuse to start, since
+// existing prod databases may already have an admin and the env var is no
+// longer needed there.
+if (APP_ENV !== 'local' && !process.env.ADMIN_USERNAME) {
+  console.warn(
+    `[env] ADMIN_USERNAME is not set on APP_ENV=${APP_ENV}. A fresh database will have no admin until the env var is set and the matching user registers.`
+  );
+}
+
 export const secrets = {
   sessionSecret: requireEnv('SESSION_SECRET')
 };

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import type { Response, NextFunction } from 'express';
 import type { AuthenticatedRequest } from '@/types';
 import { db, schema } from '@db/index';
-import { eq, and, gt, isNull } from 'drizzle-orm';
+import { eq, and, gt, isNull, desc } from 'drizzle-orm';
 import { hashSessionToken } from '@services/auth';
 
 export function authenticate() {
@@ -37,17 +37,30 @@ export function authenticate() {
       return;
     }
 
-    // Check ban status
+    // Check ban status. Order by createdAt desc so any "active ban" query
+    // elsewhere consistently sees the newest first (I15 also addresses this
+    // by writing liftedAt when an expired ban is observed).
     const activeBan = await db.query.userBans.findFirst({
       where: and(
         eq(schema.userBans.userId, session.user.id),
         isNull(schema.userBans.liftedAt)
-      )
+      ),
+      orderBy: [desc(schema.userBans.createdAt)]
     });
 
     if (activeBan) {
       if (activeBan.expiresAt && new Date(activeBan.expiresAt) < new Date()) {
-        // Ban expired — ignore
+        // I15: mark expired bans as lifted in the DB the first time we see
+        // them so future "has active ban" queries stop returning them. Best
+        // effort — if the update fails we still allow the request through.
+        try {
+          await db
+            .update(schema.userBans)
+            .set({ liftedAt: new Date().toISOString() })
+            .where(eq(schema.userBans.id, activeBan.id));
+        } catch (err) {
+          console.error('[auth] failed to mark expired ban as lifted:', err);
+        }
       } else {
         res.clearCookie('sessionId');
         res.status(403).json({

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -2,6 +2,7 @@ import type { Response, NextFunction } from 'express';
 import type { AuthenticatedRequest } from '@/types';
 import { db, schema } from '@db/index';
 import { eq, and, gt, isNull } from 'drizzle-orm';
+import { hashSessionToken } from '@services/auth';
 
 export function authenticate() {
   return async (
@@ -15,9 +16,10 @@ export function authenticate() {
       return;
     }
 
+    const tokenHash = hashSessionToken(token);
     const session = await db.query.sessions.findFirst({
       where: and(
-        eq(schema.sessions.token, token),
+        eq(schema.sessions.tokenHash, tokenHash),
         gt(schema.sessions.expiresAt, new Date().toISOString())
       ),
       with: { user: true }
@@ -96,9 +98,10 @@ export function optionalAuth() {
       return;
     }
 
+    const tokenHash = hashSessionToken(token);
     const session = await db.query.sessions.findFirst({
       where: and(
-        eq(schema.sessions.token, token),
+        eq(schema.sessions.tokenHash, tokenHash),
         gt(schema.sessions.expiresAt, new Date().toISOString())
       ),
       with: { user: true }

--- a/server/src/middleware/csrf.ts
+++ b/server/src/middleware/csrf.ts
@@ -1,0 +1,67 @@
+import type { Request, Response, NextFunction } from 'express';
+import { config } from '@lib/env';
+
+// I1: stateless CSRF defence-in-depth on top of SameSite=Lax + CORS-pin +
+// HttpOnly cookies. Rejects state-changing requests whose origin does not
+// match the deploy's baseUrl. Covers the corners SameSite misses (subdomain
+// attacks, browser bugs, sec-fetch-site=none on mutating routes).
+//
+// Strategy, per the research spike (docs/spikes/2026-06-18-...md §4):
+// 1. GET/HEAD/OPTIONS — always allowed (Express's own routing decides 404s).
+// 2. Modern browsers: trust Sec-Fetch-Site=same-origin/same-site and reject
+//    Sec-Fetch-Site=none/cross-site on mutating methods (Rails 8.2 default).
+// 3. Legacy fallback: validate Origin (preferred) or Referer header against
+//    the configured baseUrl allowlist.
+// 4. Local APP_ENV runs without a fixed origin — allow everything (matches
+//    the CORS local behaviour in src/index.ts).
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+function getAllowedOrigins(): Set<string> {
+  // baseUrl is the externally-facing origin for this deploy (set in
+  // shared/src/env.ts ENV_CONFIG). On local APP_ENV we accept the dev-server
+  // origins as well so `bun run dev` workflows aren't blocked.
+  const allowed = new Set<string>();
+  if (config.baseUrl) allowed.add(config.baseUrl);
+  if (config.appEnv === 'local') {
+    allowed.add('http://localhost:3000');
+    allowed.add('http://localhost:3001');
+    allowed.add('http://127.0.0.1:3000');
+    allowed.add('http://127.0.0.1:3001');
+  }
+  return allowed;
+}
+
+const ALLOWED_ORIGINS = getAllowedOrigins();
+
+export function csrfGuard() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (SAFE_METHODS.has(req.method)) return next();
+
+    // Sec-Fetch-Site lookup. Browsers populate this for fetch/XHR/form
+    // submissions; absence means a non-browser caller (curl, server-to-
+    // server) which we treat the same as cross-site under the strict gate.
+    const fetchSite = req.headers['sec-fetch-site'];
+    if (fetchSite === 'same-origin' || fetchSite === 'same-site') {
+      return next();
+    }
+
+    // Fallback: Origin header (preferred) or Referer.
+    const origin = (req.headers.origin as string | undefined) || '';
+    const referer = (req.headers.referer as string | undefined) || '';
+    const candidate = origin || referer;
+    if (candidate) {
+      try {
+        const url = new URL(candidate);
+        const candidateOrigin = `${url.protocol}//${url.host}`;
+        if (ALLOWED_ORIGINS.has(candidateOrigin)) {
+          return next();
+        }
+      } catch {
+        // malformed Origin/Referer — fall through to the reject path
+      }
+    }
+
+    res.status(403).json({ error: 'Cross-site request blocked' });
+  };
+}

--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -63,3 +63,42 @@ export const profileLimiter = rateLimit({
   legacyHeaders: false,
   message: { error: 'Too many profile changes, please try again later' }
 });
+
+// Password-change is bcrypt cost 12 = ~100 ms CPU per attempt. Without a
+// limiter, the route is a soft CPU-pin DoS vector for any authenticated user.
+export const passwordChangeLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many password change attempts, try again later' }
+});
+
+// Account deletion is irreversible at the API level (soft-delete + revoke
+// sessions). Low ceiling to bound abuse via stolen cookies.
+export const accountDeleteLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 3,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many account-deletion attempts' }
+});
+
+// Bulk operations are O(n) DB writes; cap concurrent bursts.
+export const bulkLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many bulk operations, please slow down' }
+});
+
+// Admin writes are by definition rare. Keep generous but bounded so a
+// runaway script can't flatten the moderation queue.
+export const adminWriteLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many admin requests, please slow down' }
+});

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -2,18 +2,34 @@ import { Router } from 'express';
 import { z } from 'zod';
 import type { AuthenticatedRequest } from '@/types';
 import { authenticate, requirePermission } from '@middleware/auth';
+import { adminWriteLimiter } from '@middleware/rateLimit';
 import * as commentService from '@services/comments';
 import * as auditService from '@services/audit';
 import { db, schema } from '@db/index';
-import { eq, and, isNull, desc, sql } from 'drizzle-orm';
-import crypto from 'crypto';
+import { eq, and, isNull, desc, sql, inArray } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
 
 const router = Router();
 
 const uuidParamSchema = z.string().uuid();
 
-// All admin routes require authentication
+// All admin routes require authentication, plus a tighter rate limit than
+// the public surface (the population is small; the limiter mainly bounds
+// runaway scripts).
 router.use(authenticate());
+router.use(adminWriteLimiter);
+
+/**
+ * Resolve the groups assigned to a user — used to enforce the
+ * "moderators cannot act on admins" boundary (I6).
+ */
+async function getUserGroupNames(userId: string): Promise<string[]> {
+  const rows = await db.query.userGroups.findMany({
+    where: eq(schema.userGroups.userId, userId),
+    with: { group: true }
+  });
+  return rows.map((ug) => ug.group.name);
+}
 
 // Dashboard
 router.get(
@@ -44,20 +60,31 @@ router.get(
         .select({ count: sql<number>`count(*)` })
         .from(schema.posts);
 
-      const recentAudit = await db.query.auditLog.findMany({
-        orderBy: [desc(schema.auditLog.createdAt)],
-        limit: 10,
-        with: {
-          admin: {
-            columns: {
-              id: true,
-              username: true,
-              displayName: true,
-              avatarUrl: true
-            }
-          }
-        }
-      });
+      // Only callers who can already view the audit log get the recent-audit
+      // slice; moderators with only `admin.dashboard` see stats but not the
+      // audit feed (I7).
+      const canSeeAudit = req.permissions?.has('admin.audit.view') ?? false;
+      const recentAudit = canSeeAudit
+        ? (
+            await db.query.auditLog.findMany({
+              orderBy: [desc(schema.auditLog.createdAt)],
+              limit: 10,
+              with: {
+                admin: {
+                  columns: {
+                    id: true,
+                    username: true,
+                    displayName: true,
+                    avatarUrl: true
+                  }
+                }
+              }
+            })
+          ).map((a) => ({
+            ...a,
+            details: a.details ? JSON.parse(a.details) : null
+          }))
+        : [];
 
       res.json({
         stats: {
@@ -66,10 +93,7 @@ router.get(
           totalComments: totalComments[0]?.count || 0,
           totalPosts: totalPosts[0]?.count || 0
         },
-        recentAudit: recentAudit.map((a) => ({
-          ...a,
-          details: a.details ? JSON.parse(a.details) : null
-        }))
+        recentAudit
       });
     } catch (error) {
       console.error('Dashboard error:', error);
@@ -183,9 +207,17 @@ router.post(
         return;
       }
 
-      for (const id of parsed.data.commentIds) {
-        await commentService.approveComment(id);
-      }
+      // I36: wrap the bulk mutation in a single transaction so a mid-list
+      // failure does not leave the set half-applied. The audit row is logged
+      // outside the transaction because audit_log entries are append-only
+      // and a partial audit + rolled-back mutation is preferable to a
+      // mutation with no audit.
+      await db.transaction(async (tx) => {
+        await tx
+          .update(schema.comments)
+          .set({ approved: 1 })
+          .where(inArray(schema.comments.id, parsed.data.commentIds));
+      });
 
       await auditService.logAuditAction(
         req.user!.id,
@@ -225,9 +257,13 @@ router.post(
         return;
       }
 
-      for (const id of parsed.data.commentIds) {
-        await commentService.rejectComment(id);
-      }
+      // I36: see note above on bulk-approve.
+      await db.transaction(async (tx) => {
+        await tx
+          .update(schema.comments)
+          .set({ deletedAt: new Date().toISOString() })
+          .where(inArray(schema.comments.id, parsed.data.commentIds));
+      });
 
       await auditService.logAuditAction(
         req.user!.id,
@@ -345,9 +381,57 @@ router.post(
         return;
       }
 
+      const targetId = idParsed.data;
+
+      // Boundary checks (I6) — without these, any user with the user.ban
+      // permission (moderators included) can ban admins, themselves, or
+      // stack a second ban on someone already banned.
+      if (targetId === req.user!.id) {
+        res.status(400).json({ error: 'Cannot ban yourself' });
+        return;
+      }
+      const targetGroups = await getUserGroupNames(targetId);
+      const targetIsAdmin = targetGroups.includes('admin');
+      const actorIsAdmin = req.permissions?.has('admin.dashboard') ?? false;
+      if (targetIsAdmin && !actorIsAdmin) {
+        res.status(403).json({ error: 'Moderators cannot ban administrators' });
+        return;
+      }
+      if (targetIsAdmin) {
+        // Refuse to leave the system without at least one admin.
+        const adminGroup = await db.query.groups.findFirst({
+          where: eq(schema.groups.name, 'admin')
+        });
+        if (adminGroup) {
+          const allAdmins = await db.query.userGroups.findMany({
+            where: eq(schema.userGroups.groupId, adminGroup.id)
+          });
+          if (allAdmins.length <= 1) {
+            res
+              .status(400)
+              .json({ error: 'Cannot ban the last remaining administrator' });
+            return;
+          }
+        }
+      }
+      const existingActiveBan = await db.query.userBans.findFirst({
+        where: and(
+          eq(schema.userBans.userId, targetId),
+          isNull(schema.userBans.liftedAt)
+        )
+      });
+      if (
+        existingActiveBan &&
+        (!existingActiveBan.expiresAt ||
+          new Date(existingActiveBan.expiresAt) > new Date())
+      ) {
+        res.status(409).json({ error: 'User is already banned' });
+        return;
+      }
+
       await db.insert(schema.userBans).values({
-        id: crypto.randomUUID(),
-        userId: idParsed.data,
+        id: randomUUID(),
+        userId: targetId,
         bannedBy: req.user!.id,
         reason: parsed.data?.reason || null,
         expiresAt: parsed.data?.expiresAt || null,
@@ -357,13 +441,13 @@ router.post(
       // Revoke all sessions
       await db
         .delete(schema.sessions)
-        .where(eq(schema.sessions.userId, idParsed.data));
+        .where(eq(schema.sessions.userId, targetId));
 
       await auditService.logAuditAction(
         req.user!.id,
         'user.ban',
         'user',
-        idParsed.data,
+        targetId,
         { reason: parsed.data?.reason },
         req.ip
       );

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { z } from 'zod';
+import bcrypt from 'bcrypt';
 import type { AuthenticatedRequest } from '@/types';
 import { authenticate } from '@middleware/auth';
 import { authLimiter } from '@middleware/rateLimit';
@@ -10,6 +11,15 @@ import { db, schema } from '@db/index';
 import { eq, desc } from 'drizzle-orm';
 
 const router = Router();
+
+// Precomputed dummy bcrypt hash, run on every failed login when the user
+// doesn't exist. Without this, the absence of a bcrypt round on the
+// missing-user branch is a measurable timing oracle for enumeration. Cost
+// matches production registrations (services/auth.ts SALT_ROUNDS = 12).
+const DUMMY_PASSWORD_HASH = bcrypt.hashSync(
+  'login-enumeration-defense-placeholder',
+  12
+);
 
 const registerSchema = z.object({
   username: z
@@ -42,19 +52,31 @@ router.post(
 
       const { username, password, email } = parsed.data;
 
+      // Username enumeration is acceptable here: usernames are publicly listed
+      // on profile pages (/profile/[username]) and on comment authorship, so
+      // hiding the conflict on /register would not actually hide membership.
       if (!(await userService.isUsernameAvailable(username))) {
         res.status(409).json({ error: 'Username already taken' });
         return;
       }
 
+      // Email is NOT publicly enumerable, so don't leak it. Without a real
+      // email-confirmation flow we can't do the full Mozilla send-on-conflict
+      // pattern; the next-best defence is to refuse with a generic message
+      // that does not distinguish "email in use" from any other server-side
+      // rejection. TODO: when an email sender is wired up, switch to 202 +
+      // queued conflict email and identical response to the success path.
       if (email) {
         const existingEmail = await db.query.users.findFirst({
           where: eq(schema.users.email, email)
         });
         if (existingEmail) {
-          res.status(409).json({
-            error: 'Email already registered'
-          });
+          res
+            .status(409)
+            .json({
+              error:
+                'Registration cannot be completed with the provided details.'
+            });
           return;
         }
       }
@@ -102,13 +124,13 @@ router.post('/login', authLimiter, async (req: AuthenticatedRequest, res) => {
     const { username, password } = parsed.data;
     const user = await userService.findUserByUsername(username);
 
-    if (!user) {
-      res.status(401).json({ error: 'Invalid credentials' });
-      return;
-    }
-
-    const valid = await authService.verifyPassword(password, user.passwordHash);
-    if (!valid) {
+    // Always run bcrypt.compare — against the real hash if the user exists,
+    // against a precomputed dummy otherwise. This removes the timing oracle
+    // (no-bcrypt-on-missing-user → ~100 ms faster response) that lets an
+    // attacker enumerate registered usernames without ever guessing a password.
+    const hashToCheck = user?.passwordHash ?? DUMMY_PASSWORD_HASH;
+    const valid = await bcrypt.compare(password, hashToCheck);
+    if (!user || !valid) {
       res.status(401).json({ error: 'Invalid credentials' });
       return;
     }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -6,6 +6,7 @@ import { authenticate } from '@middleware/auth';
 import { authLimiter } from '@middleware/rateLimit';
 import * as authService from '@services/auth';
 import * as userService from '@services/users';
+import * as auditService from '@services/audit';
 import { config } from '@lib/env';
 import { db, schema } from '@db/index';
 import { eq, desc } from 'drizzle-orm';
@@ -71,12 +72,9 @@ router.post(
           where: eq(schema.users.email, email)
         });
         if (existingEmail) {
-          res
-            .status(409)
-            .json({
-              error:
-                'Registration cannot be completed with the provided details.'
-            });
+          res.status(409).json({
+            error: 'Registration cannot be completed with the provided details.'
+          });
           return;
         }
       }
@@ -99,6 +97,17 @@ router.post(
         sameSite: 'lax',
         maxAge: 7 * 24 * 60 * 60 * 1000
       });
+
+      // I4: forensic trail for auth events. adminId on the audit row is
+      // overloaded to mean "actor" — column rename is out of scope here.
+      await auditService.logAuditAction(
+        user.id,
+        'auth.register',
+        'user',
+        user.id,
+        { username: user.username, hadEmail: !!email },
+        req.ip
+      );
 
       res.status(201).json({
         user: { id: user.id, username: user.username }
@@ -148,6 +157,15 @@ router.post('/login', authLimiter, async (req: AuthenticatedRequest, res) => {
       maxAge: 7 * 24 * 60 * 60 * 1000
     });
 
+    await auditService.logAuditAction(
+      user.id,
+      'auth.login',
+      'session',
+      session.id,
+      undefined,
+      req.ip
+    );
+
     res.json({ user: { id: user.id, username: user.username } });
   } catch (error) {
     console.error('Login error:', error);
@@ -155,22 +173,38 @@ router.post('/login', authLimiter, async (req: AuthenticatedRequest, res) => {
   }
 });
 
-router.post(
-  '/logout',
-  authenticate(),
-  async (req: AuthenticatedRequest, res) => {
-    try {
-      if (req.sessionId) {
-        await authService.revokeSession(req.sessionId);
+// I12: logout MUST be idempotent from the client's perspective. Don't gate
+// on a live session — an already-expired cookie should still clear cleanly
+// (otherwise a perfectly reasonable client action surfaces an error).
+router.post('/logout', async (req: AuthenticatedRequest, res) => {
+  try {
+    const token = req.cookies?.sessionId;
+    if (token) {
+      const tokenHash = authService.hashSessionToken(token);
+      const session = await db.query.sessions.findFirst({
+        where: eq(schema.sessions.tokenHash, tokenHash)
+      });
+      if (session) {
+        await authService.revokeSession(session.id);
+        await auditService.logAuditAction(
+          session.userId,
+          'auth.logout',
+          'session',
+          session.id,
+          undefined,
+          req.ip
+        );
       }
-      res.clearCookie('sessionId');
-      res.json({ success: true });
-    } catch (error) {
-      console.error('Logout error:', error);
-      res.status(500).json({ error: 'Internal server error' });
     }
+    res.clearCookie('sessionId');
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Logout error:', error);
+    // Even on internal error, the cookie still gets cleared client-side.
+    res.clearCookie('sessionId');
+    res.json({ success: true });
   }
-);
+});
 
 router.get('/me', authenticate(), async (req: AuthenticatedRequest, res) => {
   try {

--- a/server/src/routes/comments.ts
+++ b/server/src/routes/comments.ts
@@ -9,8 +9,36 @@ import {
   editLimiter
 } from '@middleware/rateLimit';
 import * as commentService from '@services/comments';
+import {
+  CommentValidationError,
+  CommentNotFoundError,
+  CommentAuthError
+} from '@services/comments';
 import * as postService from '@services/posts';
 import * as authService from '@services/auth';
+
+// Map typed service-layer errors to HTTP status codes. Replaces the
+// fragile stack-string heuristic (I21).
+function mapCommentError(
+  error: unknown,
+  res: import('express').Response,
+  context: string
+): void {
+  if (error instanceof CommentValidationError) {
+    res.status(400).json({ error: error.message });
+    return;
+  }
+  if (error instanceof CommentNotFoundError) {
+    res.status(404).json({ error: error.message });
+    return;
+  }
+  if (error instanceof CommentAuthError) {
+    res.status(403).json({ error: error.message });
+    return;
+  }
+  console.error(`${context} error:`, error);
+  res.status(500).json({ error: 'Internal server error' });
+}
 
 const router = Router();
 
@@ -118,13 +146,8 @@ router.post(
         type: 'comment',
         data: { commentId, postId, approved: autoApprove }
       });
-    } catch (error: any) {
-      if (error.message && !error.stack?.includes('at')) {
-        res.status(400).json({ error: error.message });
-      } else {
-        console.error('Create comment error:', error);
-        res.status(500).json({ error: 'Internal server error' });
-      }
+    } catch (error) {
+      mapCommentError(error, res, 'Create comment');
     }
   }
 );
@@ -160,13 +183,8 @@ router.patch(
         parsed.data.content
       );
       res.json({ success: true });
-    } catch (error: any) {
-      if (error.message && !error.stack?.includes('at')) {
-        res.status(400).json({ error: error.message });
-      } else {
-        console.error('Edit comment error:', error);
-        res.status(500).json({ error: 'Internal server error' });
-      }
+    } catch (error) {
+      mapCommentError(error, res, 'Edit comment');
     }
   }
 );
@@ -186,13 +204,8 @@ router.delete(
 
       await commentService.softDeleteComment(idParsed.data, req.user!.id);
       res.json({ success: true });
-    } catch (error: any) {
-      if (error.message && !error.stack?.includes('at')) {
-        res.status(400).json({ error: error.message });
-      } else {
-        console.error('Delete comment error:', error);
-        res.status(500).json({ error: 'Internal server error' });
-      }
+    } catch (error) {
+      mapCommentError(error, res, 'Delete comment');
     }
   }
 );

--- a/server/src/routes/comments.ts
+++ b/server/src/routes/comments.ts
@@ -197,21 +197,44 @@ router.delete(
   }
 );
 
-router.get('/:id/history', async (req: AuthenticatedRequest, res) => {
-  try {
-    const idParsed = uuidParamSchema.safeParse(req.params.id);
-    if (!idParsed.success) {
-      res.status(400).json({ error: 'Invalid comment ID format' });
-      return;
-    }
+// Comment edit history exposes prior revisions including deleted / unapproved
+// content, so it must NOT be public. Authenticated callers see history only
+// for their own comments, or for any comment when they hold the
+// 'comment.view.unapproved' permission (moderators / admins).
+router.get(
+  '/:id/history',
+  authenticate(),
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const idParsed = uuidParamSchema.safeParse(req.params.id);
+      if (!idParsed.success) {
+        res.status(400).json({ error: 'Invalid comment ID format' });
+        return;
+      }
 
-    const history = await commentService.getCommentHistory(idParsed.data);
-    res.json(history);
-  } catch (error) {
-    console.error('Get comment history error:', error);
-    res.status(500).json({ error: 'Internal server error' });
+      const isModerator =
+        req.permissions?.has('comment.view.unapproved') ?? false;
+      const history = await commentService.getCommentHistory(
+        idParsed.data,
+        req.user!.id,
+        isModerator
+      );
+
+      // getCommentHistory returns null when the caller is neither the author
+      // nor a moderator — translate to 403 here so the service layer stays
+      // pure data access.
+      if (history === null) {
+        res.status(403).json({ error: 'Not authorized to view this history' });
+        return;
+      }
+
+      res.json(history);
+    } catch (error) {
+      console.error('Get comment history error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
   }
-});
+);
 
 router.get(
   '/:id/replies',

--- a/server/src/routes/graph.ts
+++ b/server/src/routes/graph.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import type { AuthenticatedRequest } from '@/types';
 import { authenticate, requirePermission } from '@middleware/auth';
 import { graphLimiter } from '@middleware/rateLimit';
@@ -9,6 +10,12 @@ import {
   buildGraphIndex,
   isGraphReady
 } from '@services/graph';
+
+// SSE connection caps. Long-lived connections aren't a fit for express-rate-limit
+// (which counts requests); track open EventSource connections per user + per IP
+// in-process. Values match the security-fix-research-spike doc.
+const SSE_MAX_PER_USER = 3;
+const SSE_MAX_PER_IP = 10;
 
 const router = Router();
 
@@ -119,11 +126,25 @@ router.post(
 // SSE: Live updates for the graph
 // ============================================================================
 
-// Store active SSE connections
+// Store active SSE connections. Track user and IP for cap enforcement.
 const sseClients = new Set<{
   res: import('express').Response;
   id: string;
+  userId: string;
+  ip: string;
 }>();
+
+function countByUser(userId: string): number {
+  let n = 0;
+  for (const c of sseClients) if (c.userId === userId) n++;
+  return n;
+}
+
+function countByIp(ip: string): number {
+  let n = 0;
+  for (const c of sseClients) if (c.ip === ip) n++;
+  return n;
+}
 
 export function notifyGraphClients(event: {
   type: 'comment' | 'reaction' | 'new-post';
@@ -141,7 +162,24 @@ export function notifyGraphClients(event: {
 }
 
 // GET /api/v1/graph/live — SSE endpoint for real-time updates
-router.get('/live', (req, res) => {
+// Authenticated, with per-user and per-IP connection caps to prevent fd exhaustion.
+router.get('/live', authenticate(), (req: AuthenticatedRequest, res) => {
+  const userId = req.user!.id;
+  const ip = req.ip || 'unknown';
+
+  if (countByUser(userId) >= SSE_MAX_PER_USER) {
+    res.status(429).json({
+      error: `Too many open live connections (max ${SSE_MAX_PER_USER} per user)`
+    });
+    return;
+  }
+  if (countByIp(ip) >= SSE_MAX_PER_IP) {
+    res.status(429).json({
+      error: `Too many open live connections (max ${SSE_MAX_PER_IP} per IP)`
+    });
+    return;
+  }
+
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
@@ -152,10 +190,10 @@ router.get('/live', (req, res) => {
   // Send initial keepalive
   res.write(': connected\n\n');
 
-  const client = { res, id: crypto.randomUUID() };
+  const client = { res, id: randomUUID(), userId, ip };
   sseClients.add(client);
 
-  // Keepalive every 30 seconds
+  // Keepalive every 25 seconds (under common 30s proxy idle timeouts)
   const keepalive = setInterval(() => {
     try {
       res.write(': keepalive\n\n');
@@ -163,13 +201,15 @@ router.get('/live', (req, res) => {
       clearInterval(keepalive);
       sseClients.delete(client);
     }
-  }, 30000);
+  }, 25000);
 
-  // Cleanup on close
-  req.on('close', () => {
+  const cleanup = () => {
     clearInterval(keepalive);
     sseClients.delete(client);
-  });
+  };
+  req.on('close', cleanup);
+  req.on('error', cleanup);
+  res.on('error', cleanup);
 });
 
 export default router;

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -2,9 +2,15 @@ import { Router } from 'express';
 import { z } from 'zod';
 import type { AuthenticatedRequest } from '@/types';
 import { authenticate } from '@middleware/auth';
-import { profileLimiter } from '@middleware/rateLimit';
+import {
+  profileLimiter,
+  passwordChangeLimiter,
+  accountDeleteLimiter,
+  bulkLimiter
+} from '@middleware/rateLimit';
 import * as userService from '@services/users';
 import * as authService from '@services/auth';
+import * as auditService from '@services/audit';
 import { config } from '@lib/env';
 
 const router = Router();
@@ -116,6 +122,7 @@ router.patch(
 router.post(
   '/me/password',
   authenticate(),
+  passwordChangeLimiter,
   async (req: AuthenticatedRequest, res) => {
     try {
       const parsed = z
@@ -174,6 +181,15 @@ router.post(
         maxAge: 7 * 24 * 60 * 60 * 1000
       });
 
+      await auditService.logAuditAction(
+        req.user!.id,
+        'auth.password-change',
+        'user',
+        req.user!.id,
+        undefined,
+        req.ip
+      );
+
       res.json({ success: true });
     } catch (error) {
       console.error('Change password error:', error);
@@ -182,17 +198,30 @@ router.post(
   }
 );
 
-router.delete('/me', authenticate(), async (req: AuthenticatedRequest, res) => {
-  try {
-    await userService.softDeleteUser(req.user!.id);
-    await authService.revokeAllSessions(req.user!.id);
-    res.clearCookie('sessionId');
-    res.json({ success: true });
-  } catch (error) {
-    console.error('Delete user error:', error);
-    res.status(500).json({ error: 'Internal server error' });
+router.delete(
+  '/me',
+  authenticate(),
+  accountDeleteLimiter,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      await userService.softDeleteUser(req.user!.id);
+      await authService.revokeAllSessions(req.user!.id);
+      await auditService.logAuditAction(
+        req.user!.id,
+        'auth.account-delete',
+        'user',
+        req.user!.id,
+        undefined,
+        req.ip
+      );
+      res.clearCookie('sessionId');
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Delete user error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
   }
-});
+);
 
 router.get(
   '/me/comments',
@@ -227,6 +256,7 @@ router.get(
 router.post(
   '/me/comments/bulk-delete',
   authenticate(),
+  bulkLimiter,
   async (req: AuthenticatedRequest, res) => {
     try {
       const parsed = z

--- a/server/src/services/auth.test.ts
+++ b/server/src/services/auth.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+
+// hashSessionToken reads SESSION_TOKEN_PEPPER at module load, so isolate it:
+// reset the var and re-import via a dynamic import in each path that cares.
+function freshImport(): Promise<typeof import('./auth')> {
+  return import(`./auth?cachebust=${Math.random()}`).then((m) => m as any);
+}
+
+describe('hashSessionToken', () => {
+  test('is deterministic for the same input (no-pepper path)', async () => {
+    delete process.env.SESSION_TOKEN_PEPPER;
+    const { hashSessionToken } = await freshImport();
+    expect(hashSessionToken('abc')).toBe(hashSessionToken('abc'));
+  });
+
+  test('different inputs produce different hashes', async () => {
+    delete process.env.SESSION_TOKEN_PEPPER;
+    const { hashSessionToken } = await freshImport();
+    expect(hashSessionToken('abc')).not.toBe(hashSessionToken('abd'));
+  });
+
+  test('output is 64 hex chars (SHA-256)', async () => {
+    delete process.env.SESSION_TOKEN_PEPPER;
+    const { hashSessionToken } = await freshImport();
+    const h = hashSessionToken('any-token');
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('output does not contain the input (irreversible)', async () => {
+    delete process.env.SESSION_TOKEN_PEPPER;
+    const { hashSessionToken } = await freshImport();
+    const secret = 'super-secret-session-token-9f1c8a';
+    const h = hashSessionToken(secret);
+    expect(h.includes(secret)).toBe(false);
+  });
+
+  test('changing pepper changes the hash for the same input', async () => {
+    delete process.env.SESSION_TOKEN_PEPPER;
+    const plain = (await freshImport()).hashSessionToken('same-token');
+
+    process.env.SESSION_TOKEN_PEPPER = 'pepper-A';
+    const peppered = (await freshImport()).hashSessionToken('same-token');
+
+    expect(peppered).not.toBe(plain);
+
+    process.env.SESSION_TOKEN_PEPPER = 'pepper-B';
+    const repeppered = (await freshImport()).hashSessionToken('same-token');
+
+    expect(repeppered).not.toBe(peppered);
+
+    // Cleanup so other tests don't inherit a pepper.
+    delete process.env.SESSION_TOKEN_PEPPER;
+  });
+});

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -1,5 +1,5 @@
 import bcrypt from 'bcrypt';
-import crypto from 'crypto';
+import { randomBytes, randomUUID, createHash, createHmac } from 'node:crypto';
 import { db, schema } from '@db/index';
 import { eq, and, desc } from 'drizzle-orm';
 import { config } from '@lib/env';
@@ -7,6 +7,25 @@ import { config } from '@lib/env';
 const SALT_ROUNDS = 12;
 const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_SESSIONS_PER_USER = 5;
+
+// Optional pepper for the session-token hash. If set, the DB stores
+// HMAC-SHA256(pepper, token) instead of plain SHA-256(token). Rotation
+// invalidates every session — that is the intended operational cost.
+const SESSION_TOKEN_PEPPER = process.env.SESSION_TOKEN_PEPPER || '';
+
+/**
+ * Hash a raw session token for storage and lookup. The raw token (returned to
+ * the client as a cookie) is never persisted — the DB row only ever contains
+ * the digest, so a read-only DB leak cannot resume any live session.
+ */
+export function hashSessionToken(token: string): string {
+  if (SESSION_TOKEN_PEPPER) {
+    return createHmac('sha256', SESSION_TOKEN_PEPPER)
+      .update(token)
+      .digest('hex');
+  }
+  return createHash('sha256').update(token).digest('hex');
+}
 
 export async function hashPassword(password: string): Promise<string> {
   return bcrypt.hash(password, SALT_ROUNDS);
@@ -24,32 +43,36 @@ export async function createSession(
   userAgent?: string,
   ipAddress?: string
 ): Promise<{ id: string; token: string; expiresAt: string }> {
-  const id = crypto.randomUUID();
-  const token = crypto.randomBytes(32).toString('hex');
+  const id = randomUUID();
+  const token = randomBytes(32).toString('hex');
+  const tokenHash = hashSessionToken(token);
   const now = new Date();
   const expiresAt = new Date(now.getTime() + SESSION_EXPIRY_MS).toISOString();
 
-  // Enforce max sessions — revoke oldest if at limit
-  const existingSessions = await db.query.sessions.findMany({
-    where: eq(schema.sessions.userId, userId),
-    orderBy: [desc(schema.sessions.createdAt)]
-  });
+  // Enforce max sessions — revoke oldest if at limit. Wrapped in IMMEDIATE
+  // transaction to make the read-then-write race-safe under concurrent logins.
+  await db.transaction(async (tx) => {
+    const existingSessions = await tx.query.sessions.findMany({
+      where: eq(schema.sessions.userId, userId),
+      orderBy: [desc(schema.sessions.createdAt)]
+    });
 
-  if (existingSessions.length >= MAX_SESSIONS_PER_USER) {
-    const toRevoke = existingSessions.slice(MAX_SESSIONS_PER_USER - 1);
-    for (const s of toRevoke) {
-      await db.delete(schema.sessions).where(eq(schema.sessions.id, s.id));
+    if (existingSessions.length >= MAX_SESSIONS_PER_USER) {
+      const toRevoke = existingSessions.slice(MAX_SESSIONS_PER_USER - 1);
+      for (const s of toRevoke) {
+        await tx.delete(schema.sessions).where(eq(schema.sessions.id, s.id));
+      }
     }
-  }
 
-  await db.insert(schema.sessions).values({
-    id,
-    userId,
-    token,
-    userAgent: userAgent || null,
-    ipAddress: ipAddress || null,
-    createdAt: now.toISOString(),
-    expiresAt
+    await tx.insert(schema.sessions).values({
+      id,
+      userId,
+      tokenHash,
+      userAgent: userAgent || null,
+      ipAddress: ipAddress || null,
+      createdAt: now.toISOString(),
+      expiresAt
+    });
   });
 
   return { id, token, expiresAt };

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -8,6 +8,22 @@ const SALT_ROUNDS = 12;
 const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_SESSIONS_PER_USER = 5;
 
+/**
+ * I22: bcrypt silently truncates the input at 72 bytes, so a 200-char
+ * passphrase from a security-conscious user is in reality just its first 72
+ * bytes. Pre-hash with SHA-256 + base64 (44 chars, under 72 bytes) so the
+ * full passphrase contributes entropy, and apply NFC normalisation so
+ * combining-character forms compare equal (NIST 800-63B §5.1.1.2).
+ *
+ * This is the Dropbox-published pattern, used widely (cal.com, etc.). It
+ * works for both fresh hashes (hashPassword) and verification
+ * (verifyPassword) — the same transformation is applied on both sides.
+ */
+function prehashForBcrypt(password: string): string {
+  const normalised = password.normalize('NFC');
+  return createHash('sha256').update(normalised, 'utf8').digest('base64');
+}
+
 // Optional pepper for the session-token hash. If set, the DB stores
 // HMAC-SHA256(pepper, token) instead of plain SHA-256(token). Rotation
 // invalidates every session — that is the intended operational cost.
@@ -28,14 +44,14 @@ export function hashSessionToken(token: string): string {
 }
 
 export async function hashPassword(password: string): Promise<string> {
-  return bcrypt.hash(password, SALT_ROUNDS);
+  return bcrypt.hash(prehashForBcrypt(password), SALT_ROUNDS);
 }
 
 export async function verifyPassword(
   password: string,
   hash: string
 ): Promise<boolean> {
-  return bcrypt.compare(password, hash);
+  return bcrypt.compare(prehashForBcrypt(password), hash);
 }
 
 export async function createSession(

--- a/server/src/services/comments.ts
+++ b/server/src/services/comments.ts
@@ -1,10 +1,32 @@
 import crypto from 'crypto';
 import { db, schema } from '@db/index';
-import { eq, and, isNull, desc, asc, sql } from 'drizzle-orm';
+import { eq, and, isNull, desc, asc, sql, inArray } from 'drizzle-orm';
 import { sanitizeMarkdown } from '@middleware/sanitize';
 import type { CommentData } from '@derecksnotes/shared';
 
-const MAX_DEPTH = 5;
+export const MAX_DEPTH = 5;
+
+// Typed errors so route handlers can map to HTTP status without sniffing
+// the error stack. Replaces the fragile `error.stack?.includes('at')`
+// heuristic (I21) which silently coerced every business error to 500.
+export class CommentValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CommentValidationError';
+  }
+}
+export class CommentNotFoundError extends Error {
+  constructor(message: string = 'Comment not found') {
+    super(message);
+    this.name = 'CommentNotFoundError';
+  }
+}
+export class CommentAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CommentAuthError';
+  }
+}
 
 export async function createComment(data: {
   postId: string;
@@ -20,11 +42,15 @@ export async function createComment(data: {
       where: eq(schema.comments.id, data.parentId)
     });
 
-    if (!parent) throw new Error('Parent comment not found');
+    if (!parent) throw new CommentNotFoundError('Parent comment not found');
     if (parent.postId !== data.postId)
-      throw new Error('Parent comment belongs to different post');
+      throw new CommentValidationError(
+        'Parent comment belongs to different post'
+      );
     if (parent.depth >= MAX_DEPTH)
-      throw new Error(`Maximum reply depth of ${MAX_DEPTH} reached`);
+      throw new CommentValidationError(
+        `Maximum reply depth of ${MAX_DEPTH} reached`
+      );
     depth = parent.depth + 1;
   }
 
@@ -54,10 +80,11 @@ export async function editComment(
     where: eq(schema.comments.id, commentId)
   });
 
-  if (!comment) throw new Error('Comment not found');
+  if (!comment) throw new CommentNotFoundError();
   if (comment.userId !== userId)
-    throw new Error('Not authorized to edit this comment');
-  if (comment.deletedAt) throw new Error('Cannot edit a deleted comment');
+    throw new CommentAuthError('Not authorized to edit this comment');
+  if (comment.deletedAt)
+    throw new CommentValidationError('Cannot edit a deleted comment');
 
   // Save history snapshot of the OLD content
   await db.insert(schema.commentHistory).values({
@@ -84,10 +111,11 @@ export async function softDeleteComment(
     where: eq(schema.comments.id, commentId)
   });
 
-  if (!comment) throw new Error('Comment not found');
+  if (!comment) throw new CommentNotFoundError();
   if (comment.userId !== userId)
-    throw new Error('Not authorized to delete this comment');
-  if (comment.deletedAt) throw new Error('Comment already deleted');
+    throw new CommentAuthError('Not authorized to delete this comment');
+  if (comment.deletedAt)
+    throw new CommentValidationError('Comment already deleted');
 
   await db
     .update(schema.comments)
@@ -184,18 +212,30 @@ export async function getCommentsForPost(
 }> {
   const offset = (page - 1) * limit;
 
-  // Show approved comments + the requesting user's own unapproved comments
+  // Visibility: approved comments + the requesting user's own unapproved
+  // comments. I17: exclude soft-deleted from the top-level page so deleted
+  // top-level rows do NOT consume slots and inflate `total`.
   const visibilityFilter = userId
     ? sql`(${schema.comments.approved} = 1 OR ${schema.comments.userId} = ${userId})`
     : eq(schema.comments.approved, 1);
 
+  const topLevelWhere = and(
+    eq(schema.comments.postId, postId),
+    isNull(schema.comments.parentId),
+    isNull(schema.comments.deletedAt),
+    visibilityFilter
+  );
+
   const topLevel = await db.query.comments.findMany({
-    where: and(
-      eq(schema.comments.postId, postId),
-      isNull(schema.comments.parentId),
-      visibilityFilter
-    ),
-    orderBy: [desc(schema.comments.pinnedAt), desc(schema.comments.createdAt)],
+    where: topLevelWhere,
+    // I18: stable tiebreaker — id is the unique fallback ordering key, so
+    // offset pagination cannot repeat or skip rows when pinnedAt/createdAt
+    // collide.
+    orderBy: [
+      desc(schema.comments.pinnedAt),
+      desc(schema.comments.createdAt),
+      asc(schema.comments.id)
+    ],
     limit,
     offset,
     with: {
@@ -214,22 +254,30 @@ export async function getCommentsForPost(
   const total = await db
     .select({ count: sql<number>`count(*)` })
     .from(schema.comments)
-    .where(
-      and(
-        eq(schema.comments.postId, postId),
-        isNull(schema.comments.parentId),
-        visibilityFilter
-      )
-    );
+    .where(topLevelWhere);
 
   const totalCount = total[0]?.count || 0;
 
-  const result: CommentData[] = [];
-  for (const comment of topLevel) {
-    result.push(
-      await formatCommentTree(comment, userId, maxDepth, repliesPerLevel, 0)
-    );
-  }
+  // I16: previously formatCommentTree fired a COUNT(*) and a findMany per
+  // node, so a 20-row page with depth 3 produced ~800 SQLite round-trips.
+  // Now we collect all descendant parent ids in a single sweep (BFS over
+  // parentId IN (...)) and group counts/rows in O(1) lookups.
+  const allReplyRows = await collectDescendants(
+    topLevel.map((c) => c.id),
+    maxDepth
+  );
+  const childrenByParent = groupByParent(allReplyRows);
+
+  const result: CommentData[] = topLevel.map((c) =>
+    formatCommentTreeBatched(
+      c,
+      userId,
+      maxDepth,
+      repliesPerLevel,
+      0,
+      childrenByParent
+    )
+  );
 
   return {
     comments: result,
@@ -237,6 +285,110 @@ export async function getCommentsForPost(
     page,
     limit,
     hasMore: offset + limit < totalCount
+  };
+}
+
+/**
+ * Single-query BFS over the descendant tree. Returns every non-deleted
+ * comment whose parent chain reaches one of `rootIds`, up to `maxDepth`
+ * levels down. Replaces the previous per-node fan-out (I16).
+ */
+async function collectDescendants(
+  rootIds: string[],
+  maxDepth: number
+): Promise<any[]> {
+  if (rootIds.length === 0) return [];
+  const collected: any[] = [];
+  let frontier = rootIds;
+  for (let level = 0; level < maxDepth && frontier.length > 0; level++) {
+    const rows = await db.query.comments.findMany({
+      where: and(
+        inArray(schema.comments.parentId, frontier),
+        isNull(schema.comments.deletedAt)
+      ),
+      orderBy: [asc(schema.comments.createdAt), asc(schema.comments.id)],
+      with: {
+        user: {
+          columns: {
+            id: true,
+            username: true,
+            displayName: true,
+            avatarUrl: true
+          }
+        },
+        reactions: true
+      }
+    });
+    collected.push(...rows);
+    frontier = rows.map((r) => r.id);
+  }
+  return collected;
+}
+
+function groupByParent(rows: any[]): Map<string, any[]> {
+  const out = new Map<string, any[]>();
+  for (const r of rows) {
+    if (!r.parentId) continue;
+    const arr = out.get(r.parentId);
+    if (arr) arr.push(r);
+    else out.set(r.parentId, [r]);
+  }
+  return out;
+}
+
+function formatCommentTreeBatched(
+  comment: any,
+  userId: string | null,
+  maxDepth: number,
+  repliesPerLevel: number,
+  currentDepth: number,
+  childrenByParent: Map<string, any[]>
+): CommentData {
+  const likes =
+    comment.reactions?.filter((r: any) => r.type === 'like').length || 0;
+  const dislikes =
+    comment.reactions?.filter((r: any) => r.type === 'dislike').length || 0;
+  const userReaction = userId
+    ? (comment.reactions?.find((r: any) => r.userId === userId)?.type as
+        | 'like'
+        | 'dislike') || null
+    : null;
+
+  const allChildren = childrenByParent.get(comment.id) || [];
+  const replyCount = allChildren.length;
+  let replies: CommentData[] = [];
+  let hasMoreReplies = false;
+
+  if (currentDepth < maxDepth && replyCount > 0) {
+    const slice = allChildren.slice(0, repliesPerLevel);
+    hasMoreReplies = replyCount > repliesPerLevel;
+    replies = slice.map((child) =>
+      formatCommentTreeBatched(
+        child,
+        userId,
+        maxDepth,
+        repliesPerLevel,
+        currentDepth + 1,
+        childrenByParent
+      )
+    );
+  } else if (replyCount > 0) {
+    hasMoreReplies = true;
+  }
+
+  return {
+    id: comment.id,
+    content: comment.deletedAt ? '[deleted]' : comment.content,
+    depth: comment.depth,
+    approved: !!comment.approved,
+    createdAt: comment.createdAt,
+    editedAt: comment.editedAt,
+    isDeleted: !!comment.deletedAt,
+    user: comment.deletedAt ? null : comment.user,
+    reactions: { likes, dislikes, userReaction },
+    replies,
+    replyCount,
+    hasMoreReplies
   };
 }
 
@@ -260,7 +412,8 @@ export async function getRepliesForComment(
       isNull(schema.comments.deletedAt),
       replyVisibility
     ),
-    orderBy: [asc(schema.comments.createdAt)],
+    // I18: id tiebreaker for deterministic pagination across boundaries.
+    orderBy: [asc(schema.comments.createdAt), asc(schema.comments.id)],
     limit,
     offset,
     with: {
@@ -403,33 +556,39 @@ export async function reactToComment(
   dislikes: number;
   userReaction: 'like' | 'dislike' | null;
 }> {
-  const existing = await db.query.commentReactions.findFirst({
-    where: and(
-      eq(schema.commentReactions.commentId, commentId),
-      eq(schema.commentReactions.userId, userId)
-    )
-  });
-
-  if (existing) {
-    if (existing.type === type) {
-      await db
-        .delete(schema.commentReactions)
-        .where(eq(schema.commentReactions.id, existing.id));
-    } else {
-      await db
-        .update(schema.commentReactions)
-        .set({ type })
-        .where(eq(schema.commentReactions.id, existing.id));
-    }
-  } else {
-    await db.insert(schema.commentReactions).values({
-      id: crypto.randomUUID(),
-      commentId,
-      userId,
-      type,
-      createdAt: new Date().toISOString()
+  // I14: wrap the read-modify-write in an IMMEDIATE transaction so concurrent
+  // double-clicks can't end with mismatched state (the unique index already
+  // prevented duplicate rows, but the prior path could surface a generic
+  // 500 instead of a deterministic toggle).
+  await db.transaction(async (tx) => {
+    const existing = await tx.query.commentReactions.findFirst({
+      where: and(
+        eq(schema.commentReactions.commentId, commentId),
+        eq(schema.commentReactions.userId, userId)
+      )
     });
-  }
+
+    if (existing) {
+      if (existing.type === type) {
+        await tx
+          .delete(schema.commentReactions)
+          .where(eq(schema.commentReactions.id, existing.id));
+      } else {
+        await tx
+          .update(schema.commentReactions)
+          .set({ type })
+          .where(eq(schema.commentReactions.id, existing.id));
+      }
+    } else {
+      await tx.insert(schema.commentReactions).values({
+        id: crypto.randomUUID(),
+        commentId,
+        userId,
+        type,
+        createdAt: new Date().toISOString()
+      });
+    }
+  });
 
   return getCommentReactions(commentId, userId);
 }

--- a/server/src/services/comments.ts
+++ b/server/src/services/comments.ts
@@ -667,7 +667,8 @@ export async function getPendingComments(page: number, limit: number) {
       eq(schema.comments.approved, 0),
       isNull(schema.comments.deletedAt)
     ),
-    orderBy: [asc(schema.comments.createdAt)],
+    // Oldest first so moderation queue is FIFO.
+    orderBy: [asc(schema.comments.createdAt), asc(schema.comments.id)],
     limit,
     offset,
     with: {
@@ -676,10 +677,12 @@ export async function getPendingComments(page: number, limit: number) {
           id: true,
           username: true,
           displayName: true,
-          avatarUrl: true
+          avatarUrl: true,
+          createdAt: true
         }
       },
-      post: true
+      post: true,
+      reactions: true
     }
   });
 
@@ -690,15 +693,125 @@ export async function getPendingComments(page: number, limit: number) {
       and(eq(schema.comments.approved, 0), isNull(schema.comments.deletedAt))
     );
 
+  // Batch the per-author reputation aggregates so the queue stays O(1) DB
+  // round-trips regardless of page size.
+  const authorIds = Array.from(
+    new Set(rows.map((c) => c.userId).filter((id): id is string => !!id))
+  );
+
+  const reputationByUser = new Map<
+    string,
+    {
+      totalComments: number;
+      approvedCount: number;
+      pendingCount: number;
+      rejectedCount: number;
+      totalLikesReceived: number;
+      totalDislikesReceived: number;
+      groups: string[];
+    }
+  >();
+
+  if (authorIds.length > 0) {
+    const commentCounts = await db
+      .select({
+        userId: schema.comments.userId,
+        total: sql<number>`count(*)`,
+        approved: sql<number>`sum(case when ${schema.comments.approved} = 1 then 1 else 0 end)`,
+        pending: sql<number>`sum(case when ${schema.comments.approved} = 0 and ${schema.comments.deletedAt} is null then 1 else 0 end)`,
+        rejected: sql<number>`sum(case when ${schema.comments.approved} = 0 and ${schema.comments.deletedAt} is not null then 1 else 0 end)`
+      })
+      .from(schema.comments)
+      .where(inArray(schema.comments.userId, authorIds))
+      .groupBy(schema.comments.userId);
+
+    const reactionTotals = await db
+      .select({
+        userId: schema.comments.userId,
+        likes: sql<number>`sum(case when ${schema.commentReactions.type} = 'like' then 1 else 0 end)`,
+        dislikes: sql<number>`sum(case when ${schema.commentReactions.type} = 'dislike' then 1 else 0 end)`
+      })
+      .from(schema.commentReactions)
+      .innerJoin(
+        schema.comments,
+        eq(schema.commentReactions.commentId, schema.comments.id)
+      )
+      .where(inArray(schema.comments.userId, authorIds))
+      .groupBy(schema.comments.userId);
+
+    const groupRows = await db.query.userGroups.findMany({
+      where: inArray(schema.userGroups.userId, authorIds),
+      with: { group: true }
+    });
+
+    const groupsByUser = new Map<string, string[]>();
+    for (const g of groupRows) {
+      const list = groupsByUser.get(g.userId);
+      if (list) list.push(g.group.name);
+      else groupsByUser.set(g.userId, [g.group.name]);
+    }
+
+    const reactionsByUser = new Map(reactionTotals.map((r) => [r.userId, r]));
+
+    for (const c of commentCounts) {
+      const reactions = reactionsByUser.get(c.userId);
+      reputationByUser.set(c.userId, {
+        totalComments: c.total || 0,
+        approvedCount: c.approved || 0,
+        pendingCount: c.pending || 0,
+        rejectedCount: c.rejected || 0,
+        totalLikesReceived: reactions?.likes || 0,
+        totalDislikesReceived: reactions?.dislikes || 0,
+        groups: groupsByUser.get(c.userId) || []
+      });
+    }
+  }
+
+  const now = Date.now();
+
   return {
-    comments: rows.map((c) => ({
-      id: c.id,
-      content: c.content,
-      slug: c.post?.slug || '',
-      postTitle: c.post?.title || '',
-      createdAt: c.createdAt,
-      user: c.user
-    })),
+    comments: rows.map((c) => {
+      const reactions = c.reactions || [];
+      const commentLikes = reactions.filter((r) => r.type === 'like').length;
+      const commentDislikes = reactions.filter(
+        (r) => r.type === 'dislike'
+      ).length;
+      const rep = c.userId ? reputationByUser.get(c.userId) : undefined;
+      const authorAccountAgeDays = c.user?.createdAt
+        ? Math.max(
+            0,
+            Math.floor(
+              (now - new Date(c.user.createdAt).getTime()) /
+                (1000 * 60 * 60 * 24)
+            )
+          )
+        : 0;
+      return {
+        id: c.id,
+        content: c.content,
+        slug: c.post?.slug || '',
+        postTitle: c.post?.title || '',
+        createdAt: c.createdAt,
+        user: c.user
+          ? {
+              id: c.user.id,
+              username: c.user.username,
+              displayName: c.user.displayName,
+              avatarUrl: c.user.avatarUrl
+            }
+          : null,
+        commentLikes,
+        commentDislikes,
+        authorAccountAgeDays,
+        authorTotalComments: rep?.totalComments ?? 0,
+        authorApprovedCount: rep?.approvedCount ?? 0,
+        authorPendingCount: rep?.pendingCount ?? 0,
+        authorRejectedCount: rep?.rejectedCount ?? 0,
+        authorTotalLikesReceived: rep?.totalLikesReceived ?? 0,
+        authorTotalDislikesReceived: rep?.totalDislikesReceived ?? 0,
+        authorGroups: rep?.groups ?? []
+      };
+    }),
     total: total[0]?.count || 0
   };
 }

--- a/server/src/services/comments.ts
+++ b/server/src/services/comments.ts
@@ -95,23 +95,27 @@ export async function softDeleteComment(
     .where(eq(schema.comments.id, commentId));
 }
 
-export async function getCommentHistory(commentId: string) {
-  const entries = await db.query.commentHistory.findMany({
-    where: eq(schema.commentHistory.commentId, commentId),
-    orderBy: [desc(schema.commentHistory.editedAt)],
-    with: {
-      editor: {
-        columns: {
-          id: true,
-          username: true,
-          displayName: true,
-          avatarUrl: true
-        }
-      }
-    }
-  });
-
-  // Also include the current version
+/**
+ * Returns the full revision history of a comment, including the current
+ * version, ordered newest-first. Returns `null` when the caller is neither
+ * the comment's author nor a moderator — the caller maps that to a 403.
+ * Returns `[]` when the comment does not exist (matches the prior contract).
+ */
+export async function getCommentHistory(
+  commentId: string,
+  callerUserId: string,
+  isModerator: boolean
+): Promise<Array<{
+  id: string;
+  content: string;
+  editedAt: string;
+  editedBy: {
+    id: string;
+    username: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+  } | null;
+}> | null> {
   const comment = await db.query.comments.findFirst({
     where: eq(schema.comments.id, commentId),
     with: {
@@ -127,6 +131,24 @@ export async function getCommentHistory(commentId: string) {
   });
 
   if (!comment) return [];
+
+  const isAuthor = comment.userId === callerUserId;
+  if (!isAuthor && !isModerator) return null;
+
+  const entries = await db.query.commentHistory.findMany({
+    where: eq(schema.commentHistory.commentId, commentId),
+    orderBy: [desc(schema.commentHistory.editedAt)],
+    with: {
+      editor: {
+        columns: {
+          id: true,
+          username: true,
+          displayName: true,
+          avatarUrl: true
+        }
+      }
+    }
+  });
 
   const current = {
     id: 'current',

--- a/server/src/services/users.ts
+++ b/server/src/services/users.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { db, schema } from '@db/index';
-import { eq, and, isNull, desc, sql } from 'drizzle-orm';
+import { eq, and, isNull, desc, sql, inArray } from 'drizzle-orm';
 import { hashPassword, ensureAdminUser } from './auth';
 
 export async function createUser(data: {
@@ -157,25 +157,24 @@ export async function bulkDeleteComments(
   userId: string,
   commentIds: string[]
 ): Promise<number> {
-  let deleted = 0;
+  // Single-statement IN-list with the userId + deletedAt guard scopes the
+  // soft-delete to the caller's own undeleted comments, atomically, in one
+  // round trip. The prior version executed N statements in a loop and
+  // mis-reported `deleted` as the input length.
+  if (commentIds.length === 0) return 0;
   const now = new Date().toISOString();
-
-  for (const id of commentIds) {
-    const result = await db
-      .update(schema.comments)
-      .set({ deletedAt: now })
-      .where(
-        and(
-          eq(schema.comments.id, id),
-          eq(schema.comments.userId, userId),
-          isNull(schema.comments.deletedAt)
-        )
-      );
-
-    deleted++;
-  }
-
-  return deleted;
+  const ids = await db
+    .update(schema.comments)
+    .set({ deletedAt: now })
+    .where(
+      and(
+        inArray(schema.comments.id, commentIds),
+        eq(schema.comments.userId, userId),
+        isNull(schema.comments.deletedAt)
+      )
+    )
+    .returning({ id: schema.comments.id });
+  return ids.length;
 }
 
 export async function getReadHistory(

--- a/server/src/services/users.ts
+++ b/server/src/services/users.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { db, schema } from '@db/index';
 import { eq, and, isNull, desc, sql } from 'drizzle-orm';
-import { hashPassword } from './auth';
+import { hashPassword, ensureAdminUser } from './auth';
 
 export async function createUser(data: {
   username: string;
@@ -32,6 +32,17 @@ export async function createUser(data: {
       userId: id,
       groupId: defaultGroup.id
     });
+  }
+
+  // ADMIN_USERNAME bootstrap: if the env var matches this registration, elevate.
+  // This is how a fresh prod gets its first admin without manual SQL.
+  // Case-sensitive exact match; documented in server/.env.example.
+  const adminUsername = process.env.ADMIN_USERNAME?.trim();
+  if (adminUsername && adminUsername === data.username) {
+    await ensureAdminUser(id);
+    console.log(
+      `[admin-bootstrap] Elevated '${data.username}' to admin (matches ADMIN_USERNAME)`
+    );
   }
 
   return { id, username: data.username };

--- a/shared/src/env.ts
+++ b/shared/src/env.ts
@@ -1,4 +1,4 @@
-export type BuildEnv = 'local' | 'dev' | 'prod';
+export type AppEnv = 'local' | 'dev' | 'prod';
 
 export interface EnvConfig {
   domain: string;
@@ -6,7 +6,7 @@ export interface EnvConfig {
   apiUrl: string;
 }
 
-export const ENV_CONFIG: Record<BuildEnv, EnvConfig> = {
+export const ENV_CONFIG: Record<AppEnv, EnvConfig> = {
   local: {
     domain: 'localhost',
     baseUrl: 'http://localhost:3000',

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -191,4 +191,19 @@ export interface AdminPendingComment {
   postTitle: string;
   createdAt: string;
   user: UserBasic | null;
+  // Per-comment engagement.
+  commentLikes: number;
+  commentDislikes: number;
+  // Per-author moderation context, surfaced inline so the admin can decide
+  // without having to drill into the user's profile.
+  authorAccountAgeDays: number;
+  authorTotalComments: number;
+  authorApprovedCount: number;
+  authorPendingCount: number;
+  // Comments that were unapproved and got soft-deleted — a strong signal
+  // that prior moderation rejected this author's content.
+  authorRejectedCount: number;
+  authorTotalLikesReceived: number;
+  authorTotalDislikesReceived: number;
+  authorGroups: string[];
 }


### PR DESCRIPTION
## Summary

Full hardening of account and content surface, plus a usable admin moderation queue. Started as a small "rename + MDX fix" and grew into the security spike findings (see `docs/spikes/2026-06-18-security-fix-research.md` and the pinned comment on this PR).

No backwards-compat shims: there are no live users yet, so the session-table drop and the password pre-hash change are clean cutovers.

## What's in here

### Convention + bug fixes
- `BUILD_ENV` → `APP_ENV` across server, client (`NEXT_PUBLIC_APP_ENV`), Dockerfile, docker-compose, CI workflows, .env examples — following the [Next.js docs convention](https://nextjs.org/docs/messages/non-standard-node-env). `NODE_ENV=production` pinned at Docker build time; `entrypoint.sh` case-switch deleted.
- Dictionary `[slug]/page.tsx` now pre-builds every MDX file on dev as well as prod. The dev "slice(0,3) + dynamicParams" split was leaving the rest to an on-demand RSC compile that crashes inside `@mdx-js/mdx` recma-jsx-rewrite under Bun. Regression test (`client/src/app/dictionaries/generateStaticParams.test.ts`, 12 cases) blocks reintroduction.
- Rehype plugins (`rehypeTocCollapse`, `rehypeAddHeadingLinks`) hardened against missing/non-array nodes.
- Server `seed.ts` typecheck: non-null assertions on ~25 strict-mode array accesses.

### Security hardening
- **Session tokens hashed at rest** (audit I3) — new `sessions.token_hash` column (drizzle migration 0002), SHA-256 or HMAC-SHA256 with optional `SESSION_TOKEN_PEPPER`. Raw tokens never persisted. `createSession()` wrapped in `db.transaction()` (kills the I13 cap race). Unit tests in `auth.test.ts`.
- **SSE hardening** (B4) — explicit `node:crypto` import, `/api/v1/graph/live` gated on `authenticate()`, in-process connection-cap Map (3/user, 10/IP), tightened heartbeat to 25s.
- **`ADMIN_USERNAME` bootstrap** (B3) — `createUser()` auto-elevates the matching registration to admin so fresh prod is never locked out. Boot-time warning when `APP_ENV != local` and the var is empty.
- **Login enumeration** (I2) — precomputed `DUMMY_PASSWORD_HASH` runs on every failed login, killing the no-bcrypt-on-missing-user timing oracle. Identical response body either way.
- **Register enumeration** (I2) — generic refusal on email conflict (still a 409 but no longer says "email already registered"). Username 409 kept; usernames are publicly enumerable on profile pages anyway.
- **Comment edit history** (I5) — `/comments/:id/history` no longer public. Author or `comment.view.unapproved` permission only; 403 otherwise.
- **Admin/moderator boundary** (I6 + I7 + I15) — moderators can't ban admins, themselves, or the last admin; can't stack a second ban while one is active. `/admin/dashboard` hides the audit feed from callers without `admin.audit.view`. `authenticate()` middleware writes `liftedAt` the first time it sees an expired ban so subsequent active-ban queries stop misflagging it.
- **CSRF defence-in-depth** (I1) — new `middleware/csrf.ts` mounted on `/api/v1`. Sec-Fetch-Site same-origin/same-site → allow; otherwise Origin/Referer must match `ENV_CONFIG.baseUrl` (plus localhost on `APP_ENV=local`). GET/HEAD/OPTIONS unaffected. Matches Rails 8.2 default + the spike's §4 recommendation.
- **Rate limits** (I11) — new `passwordChangeLimiter` (5 / 15 min — bcrypt CPU pin), `accountDeleteLimiter` (3 / hr), `bulkLimiter` (10 / min), `adminWriteLimiter` (60 / min, applied to all /admin routes).
- **Audit log for auth events** (I4) — register, login, logout, password change, account delete now log to `auditLog`.
- **Logout always succeeds** (I12) — no longer requires a live session; clears the cookie even if internally errored.
- **Password length / bcrypt 72-byte truncation** (I22) — `hashPassword`/`verifyPassword` pre-hash with NFC-normalised SHA-256 → base64 before bcrypt. Full passphrase entropy contributes regardless of length.

### Comment correctness
- **I14** — `reactToComment` read-modify-write wrapped in `db.transaction()` (toggle race fix).
- **I16** — `formatCommentTree` was ~800 SQLite round-trips per 20-row page (per-node COUNT + per-node findMany). Replaced with one BFS sweep + in-memory grouping. Single-digit query count, same output.
- **I17** — top-level pagination filters `isNull(deletedAt)` so soft-deleted top-level rows don't consume slots / inflate `total`.
- **I18** — orderBy gets an `asc(id)` tiebreaker so offset pagination is deterministic across boundaries.
- **I21** — typed errors (`CommentValidationError` / `NotFoundError` / `AuthError`) replace the fragile `error.stack?.includes('at')` heuristic that silently coerced every business error to 500.
- **Bulk-delete fix** — `userService.bulkDeleteComments` did N statements and mis-reported `deleted` as the input length; now a single `inArray` UPDATE with `.returning`.

### Admin moderation queue
- Pending Comments tab is now a rich table with per-author reputation columns: account age, history (approved / rejected / pending), karma (total likes minus dislikes received), groups (admin / moderator / trusted), per-comment likes/dislikes, post link.
- Flavour badge per row: `admin`, `moderator`, `trusted`, `brand new`, `first comment`, `has rejections`, `clean history`, `unranked` — so an admin can scan without reading every row.
- Backend aggregates batched into 3 GROUP-BY queries — no N+1 regardless of page size.
- **Shift-click multi-select** — click a checkbox, shift-click another row → toggles every row in between to the new target state (standard email/file-manager convention). Anchor resets on data refetch so it can't anchor to a stale row.
- Header checkbox: indeterminate when partial selection.
- Bulk Approve / Bulk Reject buttons.

### Reusable UI primitives
- `client/src/components/ui/DataTable.tsx` — `DataTable`, `DataTableWrapper`, `DataTableCheckbox`, `SelectAllCheckbox` (the last wraps the DOM-only `indeterminate` ref dance).
- `client/src/components/ui/useRangeSelect.ts` — id-keyed multi-select hook with shift-click range semantics. 7 unit tests (`useRangeSelect.test.ts`).
- `client/src/components/ui/BulkActionBar.tsx` — toolbar that renders nothing when count is 0, with a built-in Clear button.
- `UsersTab` refactored to use the hook — gains shift-click for free, selection bound to the filtered list.

### Author-facing
- Pending comment badge now reads `pending review — only visible to you` with a tooltip explaining the auto-approve threshold so first-time commenters understand why their comment isn't showing up to others.

### Backup hardening
- `scripts/backup-db.sh` runs `PRAGMA integrity_check` + `PRAGMA foreign_key_check` before gzip, and `gunzip -t` after. Any failure removes the bad artefact + exits non-zero so the rotation can't quietly drop the last known-good copy.
- `.github/workflows/backup-db.yml` now scp's the script to the VPS and invokes it instead of inlining a duplicate (I10).

### CI
- New `.github/workflows/test.yml` — on push to master + PRs: client typecheck, server typecheck, client tests, server tests.

## Caveats / known follow-ups

- Drizzle migration `0002_session_token_hash.sql` and the journal entry are hand-written (drizzle-kit's rename prompt isn't headless-friendly). Snapshot intentionally not regenerated; a future `bun run db:generate` will detect a fresh diff and need a no-op snapshot follow-up.
- Email-conflict on `/register` is generically refused but not yet the full Mozilla send-on-conflict pattern — that arrives when an email sender is wired up.
- B2 (orphaned comments on MDX rename) explicitly accepted as "manual migration on rename" per project decision — no frontmatter UUID.
- Offsite backups (I8) and pre-deploy snapshot (I30) are not in this PR — left for a separate ops PR with cloud-creds.

## Test plan

- [x] Local: `bunx tsc --noEmit` clean on client and server
- [x] Local: `bun test` 28/28 across both workspaces
- [x] CI: new `test.yml` workflow runs typecheck + tests on push
- [x] Dev VPS deploy verified at `3c91bc53`:
  - Site regression: `/`, `/dictionaries/biology`, `/dictionaries/biology/biology_general-biology_a_ahl`, `/admin`, `/api/health` → all 200
  - Auth gates: `/api/v1/graph/live`, `/api/v1/comments/<uuid>/history`, `/api/v1/auth/me`, `/api/v1/admin/dashboard` → all 401
  - CSRF: POST without Origin → 403; with allowed Origin → reaches login (401 invalid creds)
  - Logout idempotency: no cookie → 200
  - Login enumeration: missing-user and wrong-password → identical `{"error":"Invalid credentials"}`
  - Container boot log clean (one expected ADMIN_USERNAME warning on dev, migrations applied)
